### PR TITLE
[iOS] TOTP generator, Timer 추가

### DIFF
--- a/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
+++ b/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		8835E0FE256FEF0200838FDF /* TokenEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8835E0FD256FEF0200838FDF /* TokenEditView.swift */; };
 		8835E10925701CD700838FDF /* TokenAddCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8835E10825701CD700838FDF /* TokenAddCellView.swift */; };
 		88697B5E25729682008DA21B /* TOTPGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88697B5D25729682008DA21B /* TOTPGenerationTests.swift */; };
+		88697B6F257298BD008DA21B /* TOTPGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88697B6E257298BD008DA21B /* TOTPGenerator.swift */; };
 		889CEAB7256FD336001A1D6F /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 889CEAB6256FD336001A1D6F /* CodeScanner */; };
 		889CEABC256FDE2C001A1D6F /* QRGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889CEABB256FDE2B001A1D6F /* QRGuideView.swift */; };
 		88C9D12A256D4347004956EB /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C9D129256D4347004956EB /* Token.swift */; };
@@ -81,6 +82,7 @@
 		8835E0FD256FEF0200838FDF /* TokenEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenEditView.swift; sourceTree = "<group>"; };
 		8835E10825701CD700838FDF /* TokenAddCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAddCellView.swift; sourceTree = "<group>"; };
 		88697B5D25729682008DA21B /* TOTPGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPGenerationTests.swift; sourceTree = "<group>"; };
+		88697B6E257298BD008DA21B /* TOTPGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPGenerator.swift; sourceTree = "<group>"; };
 		889CEABB256FDE2B001A1D6F /* QRGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRGuideView.swift; sourceTree = "<group>"; };
 		88C9D129256D4347004956EB /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
 		88DAA8432572880A003E6A62 /* TOTPTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPTimer.swift; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 			children = (
 				7C661930256CCAED0028E7C6 /* DaDaIkSeonApp.swift */,
 				88DAA8432572880A003E6A62 /* TOTPTimer.swift */,
+				88697B6E257298BD008DA21B /* TOTPGenerator.swift */,
 				7C661934256CCAF10028E7C6 /* Assets.xcassets */,
 				7C661939256CCAF10028E7C6 /* Info.plist */,
 			);
@@ -532,6 +535,7 @@
 			files = (
 				7CCDD299256E940600150565 /* SearchBarView.swift in Sources */,
 				889CEABC256FDE2C001A1D6F /* QRGuideView.swift in Sources */,
+				88697B6F257298BD008DA21B /* TOTPGenerator.swift in Sources */,
 				88DAA8442572880A003E6A62 /* TOTPTimer.swift in Sources */,
 				7CCDD28E256E45E000150565 /* Color+.swift in Sources */,
 				7C661933256CCAED0028E7C6 /* MainView.swift in Sources */,

--- a/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
+++ b/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		8835E10925701CD700838FDF /* TokenAddCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8835E10825701CD700838FDF /* TokenAddCellView.swift */; };
 		88697B5E25729682008DA21B /* TOTPGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88697B5D25729682008DA21B /* TOTPGenerationTests.swift */; };
 		88697B6F257298BD008DA21B /* TOTPGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88697B6E257298BD008DA21B /* TOTPGenerator.swift */; };
+		88697B7625729B5F008DA21B /* TOTPGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88697B6E257298BD008DA21B /* TOTPGenerator.swift */; };
 		889CEAB7256FD336001A1D6F /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 889CEAB6256FD336001A1D6F /* CodeScanner */; };
 		889CEABC256FDE2C001A1D6F /* QRGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889CEABB256FDE2B001A1D6F /* QRGuideView.swift */; };
 		88C9D12A256D4347004956EB /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C9D129256D4347004956EB /* Token.swift */; };
@@ -558,6 +559,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				88697B5E25729682008DA21B /* TOTPGenerationTests.swift in Sources */,
+				88697B7625729B5F008DA21B /* TOTPGenerator.swift in Sources */,
 				7C661943256CCAF20028E7C6 /* DaDaIkSeonTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
+++ b/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		88339A15256E27B80089D6B1 /* MainCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88339A14256E27B80089D6B1 /* MainCellViewModel.swift */; };
 		8835E0FE256FEF0200838FDF /* TokenEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8835E0FD256FEF0200838FDF /* TokenEditView.swift */; };
 		8835E10925701CD700838FDF /* TokenAddCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8835E10825701CD700838FDF /* TokenAddCellView.swift */; };
+		88697B5E25729682008DA21B /* TOTPGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88697B5D25729682008DA21B /* TOTPGenerationTests.swift */; };
 		889CEAB7256FD336001A1D6F /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 889CEAB6256FD336001A1D6F /* CodeScanner */; };
 		889CEABC256FDE2C001A1D6F /* QRGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889CEABB256FDE2B001A1D6F /* QRGuideView.swift */; };
 		88C9D12A256D4347004956EB /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C9D129256D4347004956EB /* Token.swift */; };
@@ -79,6 +80,7 @@
 		88339A14256E27B80089D6B1 /* MainCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCellViewModel.swift; sourceTree = "<group>"; };
 		8835E0FD256FEF0200838FDF /* TokenEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenEditView.swift; sourceTree = "<group>"; };
 		8835E10825701CD700838FDF /* TokenAddCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAddCellView.swift; sourceTree = "<group>"; };
+		88697B5D25729682008DA21B /* TOTPGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPGenerationTests.swift; sourceTree = "<group>"; };
 		889CEABB256FDE2B001A1D6F /* QRGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRGuideView.swift; sourceTree = "<group>"; };
 		88C9D129256D4347004956EB /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
 		88DAA8432572880A003E6A62 /* TOTPTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPTimer.swift; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				7C661942256CCAF20028E7C6 /* DaDaIkSeonTests.swift */,
+				88697B5D25729682008DA21B /* TOTPGenerationTests.swift */,
 				7C661944256CCAF20028E7C6 /* Info.plist */,
 			);
 			path = DaDaIkSeonTests;
@@ -235,9 +238,9 @@
 			isa = PBXGroup;
 			children = (
 				7C661930256CCAED0028E7C6 /* DaDaIkSeonApp.swift */,
+				88DAA8432572880A003E6A62 /* TOTPTimer.swift */,
 				7C661934256CCAF10028E7C6 /* Assets.xcassets */,
 				7C661939256CCAF10028E7C6 /* Info.plist */,
-				88DAA8432572880A003E6A62 /* TOTPTimer.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -277,6 +280,7 @@
 				7C66192A256CCAED0028E7C6 /* Frameworks */,
 				7C66192B256CCAED0028E7C6 /* Resources */,
 				7C7DC4DA256CD47B0089CD68 /* ShellScript */,
+				1FF3AB2F8B59E4824D475AE1 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -317,6 +321,7 @@
 				7C661945256CCAF20028E7C6 /* Sources */,
 				7C661946256CCAF20028E7C6 /* Frameworks */,
 				7C661947256CCAF20028E7C6 /* Resources */,
+				FDF7D914DA5224B4E73FC658 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -401,6 +406,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1FF3AB2F8B59E4824D475AE1 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-DaDaIkSeon/Pods-DaDaIkSeon-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-DaDaIkSeon/Pods-DaDaIkSeon-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DaDaIkSeon/Pods-DaDaIkSeon-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		5F61C169C8A7711A65570044 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -484,6 +506,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		FDF7D914DA5224B4E73FC658 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-DaDaIkSeon-DaDaIkSeonUITests/Pods-DaDaIkSeon-DaDaIkSeonUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-DaDaIkSeon-DaDaIkSeonUITests/Pods-DaDaIkSeon-DaDaIkSeonUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DaDaIkSeon-DaDaIkSeonUITests/Pods-DaDaIkSeon-DaDaIkSeonUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -514,6 +553,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88697B5E25729682008DA21B /* TOTPGenerationTests.swift in Sources */,
 				7C661943256CCAF20028E7C6 /* DaDaIkSeonTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
+++ b/iOS/DaDaIkSeon/DaDaIkSeon.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		889CEAB7256FD336001A1D6F /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 889CEAB6256FD336001A1D6F /* CodeScanner */; };
 		889CEABC256FDE2C001A1D6F /* QRGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889CEABB256FDE2B001A1D6F /* QRGuideView.swift */; };
 		88C9D12A256D4347004956EB /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C9D129256D4347004956EB /* Token.swift */; };
+		88DAA8442572880A003E6A62 /* TOTPTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88DAA8432572880A003E6A62 /* TOTPTimer.swift */; };
 		8B3BF03307497E82800CB6D1 /* Pods_DaDaIkSeonTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7375BCD76D276087540F5A /* Pods_DaDaIkSeonTests.framework */; };
 		8FB143B0B01FA7993CFEAC9C /* Pods_DaDaIkSeon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 981E93FC9FDFEEB9721B6608 /* Pods_DaDaIkSeon.framework */; };
 /* End PBXBuildFile section */
@@ -80,6 +81,7 @@
 		8835E10825701CD700838FDF /* TokenAddCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAddCellView.swift; sourceTree = "<group>"; };
 		889CEABB256FDE2B001A1D6F /* QRGuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRGuideView.swift; sourceTree = "<group>"; };
 		88C9D129256D4347004956EB /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
+		88DAA8432572880A003E6A62 /* TOTPTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPTimer.swift; sourceTree = "<group>"; };
 		90688457817CB7719705FC9F /* Pods-DaDaIkSeon-DaDaIkSeonUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DaDaIkSeon-DaDaIkSeonUITests.debug.xcconfig"; path = "Target Support Files/Pods-DaDaIkSeon-DaDaIkSeonUITests/Pods-DaDaIkSeon-DaDaIkSeonUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		981E93FC9FDFEEB9721B6608 /* Pods_DaDaIkSeon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DaDaIkSeon.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7BCEA6C2EC7E8E6CF1AF83B /* Pods-DaDaIkSeon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DaDaIkSeon.debug.xcconfig"; path = "Target Support Files/Pods-DaDaIkSeon/Pods-DaDaIkSeon.debug.xcconfig"; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				7C661930256CCAED0028E7C6 /* DaDaIkSeonApp.swift */,
 				7C661934256CCAF10028E7C6 /* Assets.xcassets */,
 				7C661939256CCAF10028E7C6 /* Info.plist */,
+				88DAA8432572880A003E6A62 /* TOTPTimer.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -490,6 +493,7 @@
 			files = (
 				7CCDD299256E940600150565 /* SearchBarView.swift in Sources */,
 				889CEABC256FDE2C001A1D6F /* QRGuideView.swift in Sources */,
+				88DAA8442572880A003E6A62 /* TOTPTimer.swift in Sources */,
 				7CCDD28E256E45E000150565 /* Color+.swift in Sources */,
 				7C661933256CCAED0028E7C6 /* MainView.swift in Sources */,
 				7CE395A12570968F00F3C813 /* View+.swift in Sources */,

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPGenerator.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPGenerator.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftOTP
 
-class TOTPGenerator {
+final class TOTPGenerator {
     
     static func generate(from key: String) -> String? {
         
@@ -34,10 +34,9 @@ class TOTPGenerator {
     static func extractKey(from urlOfQrcode: String) -> String? {
         let items = URLComponents(string: urlOfQrcode)?.queryItems
         if let items = items {
-            for index in items.indices {
-                if items[index].name == "secret" {
-                    return items[index].value
-                }
+            for index in items.indices
+            where items[index].name == "secret" {
+                return items[index].value
             }
         }
         return nil

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPGenerator.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPGenerator.swift
@@ -1,0 +1,46 @@
+//
+//  TOTPGenerator.swift
+//  DaDaIkSeon
+//
+//  Created by 정재명 on 2020/11/28.
+//
+
+import Foundation
+import SwiftOTP
+
+class TOTPGenerator {
+    
+    static func generate(from key: String) -> String? {
+        
+        guard let keyData = base32DecodeToData(key) else {
+            return nil
+        }
+        
+        guard let totp = TOTP(
+                secret: keyData,
+                digits: 6,
+                timeInterval: 30,
+                algorithm: .sha1) else {
+            return nil
+        }
+        guard let password = totp.generate(
+                secondsPast1970: Int(Date().timeIntervalSince1970))
+        else {
+            return nil
+        }
+        return password
+    }
+    
+    static func extractKey(from urlOfQrcode: String) -> String? {
+        let items = URLComponents(string: urlOfQrcode)?.queryItems
+        if let items = items {
+            for index in items.indices {
+                if items[index].name == "secret" {
+                    return items[index].value
+                }
+            }
+        }
+        return nil
+    }
+    
+}

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-class TOTPTimer {
+final class TOTPTimer {
     
     let totalTime = 30.0
     let timerInterval = 0.01

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
@@ -1,0 +1,27 @@
+//
+//  TOTPTimer.swift
+//  DaDaIkSeon
+//
+//  Created by 정재명 on 2020/11/28.
+//
+
+import Foundation
+import Combine
+
+class TOTPTimer {
+    
+    let totalTime = 30.0
+    let timerInterval = 0.01
+    
+    let timer: Publishers.Autoconnect<Timer.TimerPublisher>
+    
+    static var shared = TOTPTimer()
+    
+    private init() {
+        
+        timer = Timer
+            .publish(every: timerInterval, on: .main, in: .common)
+            .autoconnect()
+        
+    }
+}

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/Model/Token.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/Model/Token.swift
@@ -13,4 +13,39 @@ struct Token: Identifiable {
     var tokenName: String?
     var color: String?
     var icon: String?
+    
+    static func dummy() -> [Token] {
+        [
+            Token(id: UUID(),
+                  key: "WEJ3NLTTYHF4XVXG",
+                  tokenName: "배고파",
+                  color: "pink",
+                  icon: nil),
+            Token(id: UUID(),
+                  key: "nv66p42pcv4f2fbgetakq6clottovx7z",
+                  tokenName: "네이버2",
+                  color: "salmon",
+                  icon: nil),
+            Token(id: UUID(),
+                  key: "WEJ3NLTTYHF4XVXG",
+                  tokenName: "네이버",
+                  color: "navy",
+                  icon: nil),
+            Token(id: UUID(),
+                  key: "6UAOpz+x3dsNrQ==",
+                  tokenName: "구글",
+                  color: "blue",
+                  icon: nil),
+            Token(id: UUID(),
+                  key: "nv66p42pcv4f2fbgetakq6clottovx7z",
+                  tokenName: "배아파",
+                  color: "brown",
+                  icon: nil),
+            Token(id: UUID(),
+                  key: "nv66p42pcv4f2fbgetakq6clottovx7z",
+                  tokenName: "배아파",
+                  color: "mint",
+                  icon: nil)
+        ]
+    }
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/Model/Token.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/Model/Token.swift
@@ -32,7 +32,7 @@ struct Token: Identifiable {
                   color: "navy",
                   icon: nil),
             Token(id: UUID(),
-                  key: "6UAOpz+x3dsNrQ==",
+                  key: "WEJ3NLTTYHF4XVXG",
                   tokenName: "구글",
                   color: "blue",
                   icon: nil),

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainCellView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainCellView.swift
@@ -11,14 +11,9 @@ struct MainCellView: View {
     
     // MARK: ViewModel
     @ObservedObject var mainCellViewModel = MainCellViewModel()
-    @Binding var token: Token
     
     // MARK: Property
     let zStackHeight: CGFloat = 200.0
-    
-    init(token: Binding<Token>) {
-        self._token = token
-    }
     
     // MARK: Body
     var body: some View {
@@ -135,7 +130,7 @@ struct MainCellView_Previews: PreviewProvider {
     
     static var previews: some View {
         //PreviewWrapper()
-        MainCellView(token: .constant(Token(id: UUID())))
+        MainCellView()
     }
     
     //    struct PreviewWrapper: View {

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainView.swift
@@ -31,7 +31,7 @@ struct MainView: View {
                 HeaderView()
                 SearchBarView()
                 viewModel.isSearching ?
-                    nil : MainCellView(token: .constant(viewModel.mainCell))
+                    nil : MainCellView()
                     .padding(.bottom, -6)
                 ScrollView {
                     LazyVGrid(columns: columns,

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
@@ -11,9 +11,6 @@ import Combine
 
 class MainCellViewModel: ObservableObject {
     
-    /// MARK: Model
-    /// 토큰 모델? -> 여기에 컬러, 아이콘, 키 값, 이름 정보가 있음.
-    /// 토큰을 바인딩하고 있는 게 편할 것 같다. 여기서 수정해도 바로 원본이 수정되니까!
     // MARK: 토큰 값을 viewmodel이 가지고 있을 필요가 없다. 그냥 토큰에서 필요한 값만 가져와 published에 할당하면 끝! 셀 데이터를 수정하게 되면, 전역적으로 접근 가능한 mainviewmodel의 tokens의 값을 변경시켜주면 된다.
     
     // MARK: Property

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
@@ -27,19 +27,14 @@ class MainCellViewModel: ObservableObject {
     @Published var timeAmount = 0.0
     @Published var password = ""
     
-    let totalTime = 30.0
-    let timerInterval = 0.01
+    let totalTime = TOTPTimer.shared.totalTime
+    let timerInterval = TOTPTimer.shared.timerInterval
     
     var subscriptions = Set<AnyCancellable>()
-    
-    let timer: Publishers.Autoconnect<Timer.TimerPublisher>
     
     var lastSecond: Int = 1
     
     init() {
-        
-        timer = Timer.publish(every: timerInterval, on: .main, in: .common)
-            .autoconnect()
         
         password = makePassword(key: key)
         
@@ -47,7 +42,7 @@ class MainCellViewModel: ObservableObject {
             = Date().timeIntervalSince1970
             .truncatingRemainder(dividingBy: totalTime) + 1
         
-        timer
+        TOTPTimer.shared.timer
             .map({ (output) in
                 output.timeIntervalSince1970
             })

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
@@ -16,7 +16,7 @@ class MainCellViewModel: ObservableObject {
     // MARK: Property
     
     // 토큰 모델에서 값 가져와야한다.
-    let key = "6UAOpz+x3dsNrQ=="
+    let key = "WEJ3NLTTYHF4XVXG"
     
     @Published var tokenName = "토큰의이름은두줄두줄두줄두줄두줄두줄두줄두줄두줄"
     
@@ -33,7 +33,7 @@ class MainCellViewModel: ObservableObject {
     
     init() {
         
-        password = makePassword(key: key)
+        password = TOTPGenerator.generate(from: key) ?? "000000"
         
         timeAmount
             = Date().timeIntervalSince1970
@@ -52,7 +52,7 @@ class MainCellViewModel: ObservableObject {
                     weakSelf.timeString = "\(seconds + 1)"
                     if seconds == 0 {
                         weakSelf.password
-                            = weakSelf.makePassword(key: weakSelf.key)
+                            = TOTPGenerator.generate(from: weakSelf.key) ?? "000000"
                         weakSelf.timeAmount = 0
                     }
                     weakSelf.lastSecond = seconds
@@ -70,41 +70,6 @@ class MainCellViewModel: ObservableObject {
     
     func copyButtonDidTab() {
         print("CopyButtonDidTab")
-    }
-    
-    // MARK: Logic
-    
-    func makePassword(key: String) -> String {
-        
-        let period = TimeInterval(totalTime)
-        let digits = 6
-        
-        // 키 값
-        guard let secret = Data(base64Encoded: key) else {
-            return "000000"
-        }
-        
-        // 현재 시간
-        var counter = UInt64(Date().timeIntervalSince1970 / period).bigEndian
-        let counterData = withUnsafeBytes(of: &counter) { Array($0) }
-        
-        // HMAC 알고리즘 연산
-        let hash = HMAC<Insecure.SHA1>.authenticationCode(
-            for: counterData, using: SymmetricKey(data: secret))
-        
-        // 추출
-        var truncatedHash = hash.withUnsafeBytes { ptr -> UInt32 in
-            let offset = ptr[hash.byteCount - 1] & 0x0f
-            guard let baseAddress = ptr.baseAddress else { return 0 }
-            let truncatedHashPtr = baseAddress + Int(offset)
-            return truncatedHashPtr.bindMemory(to: UInt32.self, capacity: 1).pointee
-        }
-        
-        truncatedHash = UInt32(bigEndian: truncatedHash)
-        truncatedHash = truncatedHash & 0x7FFF_FFFF
-        truncatedHash = truncatedHash & UInt32(pow(10, Float(digits)))
-        
-        return "\(String(format: "%0*u", digits, truncatedHash))"
     }
     
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainCellViewModel.swift
@@ -11,9 +11,10 @@ import Combine
 
 class MainCellViewModel: ObservableObject {
     
-    // MARK: Model
-    // 토큰 모델? -> 여기에 컬러, 아이콘, 키 값, 이름 정보가 있음.
-    // 토큰을 바인딩하고 있는 게 편할 것 같다. 여기서 수정해도 바로 원본이 수정되니까!
+    /// MARK: Model
+    /// 토큰 모델? -> 여기에 컬러, 아이콘, 키 값, 이름 정보가 있음.
+    /// 토큰을 바인딩하고 있는 게 편할 것 같다. 여기서 수정해도 바로 원본이 수정되니까!
+    // MARK: 토큰 값을 viewmodel이 가지고 있을 필요가 없다. 그냥 토큰에서 필요한 값만 가져와 published에 할당하면 끝! 셀 데이터를 수정하게 되면, 전역적으로 접근 가능한 mainviewmodel의 tokens의 값을 변경시켜주면 된다.
     
     // MARK: Property
     
@@ -35,16 +36,7 @@ class MainCellViewModel: ObservableObject {
     
     var lastSecond: Int = 1
     
-    let dateFormmater = DateFormatter()
-    var todaySartTime: Date? {
-        let today = dateFormmater.string(from: Date())
-        return dateFormmater.date(from: today)
-    }
-    
     init() {
-        
-        dateFormmater.locale = Locale(identifier: "ko_KR")
-        dateFormmater.dateFormat = "yyyy-MM-dd"
         
         timer = Timer.publish(every: timerInterval, on: .main, in: .common)
             .autoconnect()
@@ -52,15 +44,15 @@ class MainCellViewModel: ObservableObject {
         password = makePassword(key: key)
         
         timeAmount
-            = -Double(todaySartTime?.timeIntervalSinceNow ?? 0)
+            = Date().timeIntervalSince1970
             .truncatingRemainder(dividingBy: totalTime) + 1
         
         timer
             .map({ (output) in
-                return output.timeIntervalSince(self.todaySartTime ?? Date())
+                output.timeIntervalSince1970
             })
             .map({ (timeInterval) in
-                return Int(timeInterval) % Int(self.totalTime)
+                Int(timeInterval.truncatingRemainder(dividingBy: self.totalTime))
             })
             .sink { [weak self] (seconds) in
                 guard let weakSelf = self else { return }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainViewModel.swift
@@ -15,11 +15,6 @@ final class MainViewModel: ObservableObject {
     @Published var filteredTokens: [TokenViewModel] = []
     @Published var searchText = ""
     @Published var isSearching = false
-    @Published var mainCell
-        = Token(id: UUID(),
-                key: "6UAOpz+x3dsNrQ==",
-                tokenName: "토큰의 이름은 두 줄 까지만 가능합니다.",
-                color: nil, icon: nil)
     
     var publisher: AnyCancellable?
     var tokens: [TokenViewModel] = []
@@ -48,42 +43,9 @@ final class MainViewModel: ObservableObject {
     
     /// 토큰 배열을 리턴
     func fetchTokens() {
-        tokens = [
-            TokenViewModel(
-                token: Token(id: UUID(),
-                             key: "WEJ3NLTTYHF4XVXG",
-                             tokenName: "배고파",
-                             color: "pink",
-                             icon: nil)
-            ),
-            TokenViewModel(
-                token: Token(id: UUID(),
-                             key: "nv66p42pcv4f2fbgetakq6clottovx7z",
-                             tokenName: "네이버2",
-                             color: "salmon",
-                             icon: nil)
-            ),
-            TokenViewModel(
-                token: Token(id: UUID(),
-                             key: "WEJ3NLTTYHF4XVXG",
-                             tokenName: "네이버",
-                             color: "navy",
-                             icon: nil)
-            ),
-            TokenViewModel(
-                token: Token(id: UUID(),
-                             key: "6UAOpz+x3dsNrQ==",
-                             tokenName: "구글",
-                             color: "blue",
-                             icon: nil)
-            ),
-            TokenViewModel(
-                token: Token(id: UUID(),
-                             key: "nv66p42pcv4f2fbgetakq6clottovx7z",
-                             tokenName: "배아파",
-                             color: "brown",
-                             icon: nil)
-            )]
+        tokens = Token.dummy().map {
+            TokenViewModel(token: $0)
+        }
     }
     
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainViewModel.swift
@@ -11,9 +11,7 @@ import Combine
 final class MainViewModel: ObservableObject {
     
     // MARK: Property
-    let timer = Timer.publish(every: 0.01, on: .main, in: .common)
-        .autoconnect()
-    
+
     @Published var filteredTokens: [TokenViewModel] = []
     @Published var searchText = ""
     @Published var isSearching = false
@@ -56,41 +54,35 @@ final class MainViewModel: ObservableObject {
                              key: "WEJ3NLTTYHF4XVXG",
                              tokenName: "배고파",
                              color: "pink",
-                             icon: nil),
-                timer: timer
+                             icon: nil)
             ),
             TokenViewModel(
                 token: Token(id: UUID(),
                              key: "nv66p42pcv4f2fbgetakq6clottovx7z",
                              tokenName: "네이버2",
                              color: "salmon",
-                             icon: nil),
-                timer: timer
+                             icon: nil)
             ),
             TokenViewModel(
                 token: Token(id: UUID(),
                              key: "WEJ3NLTTYHF4XVXG",
                              tokenName: "네이버",
                              color: "navy",
-                             icon: nil),
-                timer: timer
+                             icon: nil)
             ),
             TokenViewModel(
                 token: Token(id: UUID(),
                              key: "6UAOpz+x3dsNrQ==",
                              tokenName: "구글",
                              color: "blue",
-                             icon: nil),
-                timer: timer
+                             icon: nil)
             ),
             TokenViewModel(
                 token: Token(id: UUID(),
                              key: "nv66p42pcv4f2fbgetakq6clottovx7z",
                              tokenName: "배아파",
                              color: "brown",
-                             icon: nil),
-                timer: timer
-                    
+                             icon: nil)
             )]
     }
     

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenViewModel.swift
@@ -25,41 +25,28 @@ final class TokenViewModel: ObservableObject {
     @Published var color = "pink"
     @Published var password = ""
     
-    let totalTime = 30.0
-    let timerInterval = 0.01
+    let totalTime = TOTPTimer.shared.totalTime
+    let timerInterval = TOTPTimer.shared.timerInterval
     
     var subscriptions = Set<AnyCancellable>()
     
-    let timer: Publishers.Autoconnect<Timer.TimerPublisher>
-    
     var lastSecond: Int = 1
-    
-    let dateFormmater = DateFormatter()
-    var todaySartTime: Date? {
-        let today = dateFormmater.string(from: Date())
-        return dateFormmater.date(from: today)
-    }
       
     // MARK: init
     
-    init(token: Token, timer: Publishers.Autoconnect<Timer.TimerPublisher>) {
+    init(token: Token) {
         
         self.token = token
         self.color = token.color ?? "pink"
-        
-        dateFormmater.locale = Locale(identifier: "ko_KR")
-        dateFormmater.dateFormat = "yyyy-MM-dd"
-        
-        self.timer = timer
-            
+          
         password = makePassword(key: key)
         
-        timer
+        TOTPTimer.shared.timer
             .map({ (output) in
-                return output.timeIntervalSince(self.todaySartTime ?? Date())
+                output.timeIntervalSince1970
             })
             .map({ (timeInterval) in
-                return Int(timeInterval) % Int(self.totalTime)
+                Int(timeInterval.truncatingRemainder(dividingBy: self.totalTime))
             })
             .sink { [weak self] (seconds) in
                 guard let weakSelf = self else { return }

--- a/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
@@ -10,19 +10,7 @@ import SwiftOTP
 
 class TOTPGenerationTests: XCTestCase {
     
-    // MARK: function
-    var extractKey: (String) -> String? {
-        TOTPGenerator.extractKey(from:)
-    }
-    
-    var generateTOTP: (String) -> String? {
-        TOTPGenerator.generate(from:)
-    }
-    
     // MARK: URL
-    var testURLs: [String] {
-        [github, google]
-    }
     let github = "otpauth://totp/GitHub:jjm159?secret=WEJ3NLTTYHF4XVXG&issuer=GitHub"
     let google = "otpauth://totp/Google%3Awjdwoaud15%40gmail.com?secret=fn3gdedtxfsluaz4qlcv7ndhowimn4h2&issuer=Google"
     
@@ -97,7 +85,10 @@ class TOTPGenerationTests: XCTestCase {
     
 }
 
+// MARK: function
+
 extension TOTPGenerationTests {
+    
     func keyData(from urlOfQrcode: String) -> Data? {
         guard let keyString = extractKey(urlOfQrcode) else {
             return nil
@@ -107,4 +98,17 @@ extension TOTPGenerationTests {
         }
         return nil
     }
+    
+    var testURLs: [String] {
+        [github, google]
+    }
+    
+    var extractKey: (String) -> String? {
+        TOTPGenerator.extractKey(from:)
+    }
+    
+    var generateTOTP: (String) -> String? {
+        TOTPGenerator.generate(from:)
+    }
+    
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
@@ -1,0 +1,14 @@
+//
+//  TOTPGenerationTests.swift
+//  DaDaIkSeonTests
+//
+//  Created by 정재명 on 2020/11/28.
+//
+
+import XCTest
+import SwiftOTP
+
+class TOTPGenerationTests: XCTestCase {
+    
+    
+}

--- a/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
@@ -10,5 +10,26 @@ import SwiftOTP
 
 class TOTPGenerationTests: XCTestCase {
     
+    var extractKey: (String) -> String? {
+        TOTPGenerator.extractKey(from: )
+    }
+    
+    let github = "otpauth://totp/GitHub:jjm159?secret=WEJ3NLTTYHF4XVXG&issuer=GitHub"
+    let google = "otpauth://totp/Google%3Awjdwoaud15%40gmail.com?secret=fn3gdedtxfsluaz4qlcv7ndhowimn4h2&issuer=Google"
+    
+    func test_qrcode로부터읽어온_url에서_키값추출이_되어야한다() {
+        XCTAssertEqual(extractKey(github), "WEJ3NLTTYHF4XVXG")
+        XCTAssertEqual(extractKey(google), "fn3gdedtxfsluaz4qlcv7ndhowimn4h2")
+    }
+    
+    func test_잘못된urlstring을주면_nil이_반환되어야한다() {
+        let wrongString = "otpauth://totp/GitHub:jjm159?secr=WEJ3NLTTYHF4XVXG&issuer=GitHub"
+        XCTAssertNil(extractKey(wrongString))
+    }
+    
+    
+}
+
+extension TOTPGenerationTests {
     
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeonTests/TOTPGenerationTests.swift
@@ -10,13 +10,20 @@ import SwiftOTP
 
 class TOTPGenerationTests: XCTestCase {
     
+    // MARK: function
     var extractKey: (String) -> String? {
-        TOTPGenerator.extractKey(from: )
+        TOTPGenerator.extractKey(from:)
     }
     
+    var generateTOTP: (String) -> String? {
+        TOTPGenerator.generate(from:)
+    }
+    
+    // MARK: URL
     let github = "otpauth://totp/GitHub:jjm159?secret=WEJ3NLTTYHF4XVXG&issuer=GitHub"
     let google = "otpauth://totp/Google%3Awjdwoaud15%40gmail.com?secret=fn3gdedtxfsluaz4qlcv7ndhowimn4h2&issuer=Google"
     
+    // MARK: Test Code
     func test_qrcode로부터읽어온_url에서_키값추출이_되어야한다() {
         XCTAssertEqual(extractKey(github), "WEJ3NLTTYHF4XVXG")
         XCTAssertEqual(extractKey(google), "fn3gdedtxfsluaz4qlcv7ndhowimn4h2")
@@ -27,9 +34,42 @@ class TOTPGenerationTests: XCTestCase {
         XCTAssertNil(extractKey(wrongString))
     }
     
+    func test_추출한_키값으로부터_base32기반_디코딩이_되어야한다() {
+        guard let keyString = extractKey(github) else {
+            XCTFail("키 값 생성 실패")
+            return
+        }
+        XCTAssertNotNil(base32DecodeToData(keyString))
+    }
+    
+    func test_추출한_키값이_base32기반으로_인코딩된데이터가_아닌경우_nil을반환해야한다() {
+        // TODO: 추출한 키값이 base32기반 인코딩된 데이터가 아닌 경우 test해야 한다.
+    }
+    
+    func test_키값으로부터_TOTP객체가_생성되어야한다() {
+        guard let keyData = keyData(from: github) else {
+            XCTFail("키 데이터 생성 실패")
+            return
+        }
+        XCTAssertNotNil(
+            TOTP(secret: keyData,
+                 digits: 6,
+                 timeInterval: 30,
+                 algorithm: .sha1)
+        )
+        
+    }
     
 }
 
 extension TOTPGenerationTests {
-    
+    func keyData(from urlOfQrcode: String) -> Data? {
+        guard let keyString = extractKey(urlOfQrcode) else {
+            return nil
+        }
+        if let keyData = base32DecodeToData(keyString) {
+            return keyData
+        }
+        return nil
+    }
 }

--- a/iOS/DaDaIkSeon/Podfile
+++ b/iOS/DaDaIkSeon/Podfile
@@ -7,6 +7,7 @@ target 'DaDaIkSeon' do
 
   # Pods for DaDaIkSeon
   pod 'SwiftLint'
+  pod 'SwiftOTP'
 
   target 'DaDaIkSeonTests' do
     inherit! :search_paths

--- a/iOS/DaDaIkSeon/Podfile.lock
+++ b/iOS/DaDaIkSeon/Podfile.lock
@@ -1,16 +1,24 @@
 PODS:
+  - CryptoSwift (1.3.7)
   - SwiftLint (0.41.0)
+  - SwiftOTP (2.0.3):
+    - CryptoSwift (>= 1.0.0)
 
 DEPENDENCIES:
   - SwiftLint
+  - SwiftOTP
 
 SPEC REPOS:
   trunk:
+    - CryptoSwift
     - SwiftLint
+    - SwiftOTP
 
 SPEC CHECKSUMS:
+  CryptoSwift: b6faad405e69964740422daf121918b5b1870f2b
   SwiftLint: c585ebd615d9520d7fbdbe151f527977b0534f1e
+  SwiftOTP: ce98ded1ab42e4e66c39228fcad6b0c07b98e494
 
-PODFILE CHECKSUM: c45566641398b2cb97278ae27cc66b0faebdf366
+PODFILE CHECKSUM: 46b8295042d5bbebc0948eff0095318c359f3e7c
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- TOTPTimer 추가
- TOTPGenerator 추가
- TOTPGenerator 테스트 코드 추가
- SwiftOTP 라이브러리 추가 

## :hammer: 변경로직

- 지금 MainCellViewModel과 TokenViewModel이 매우 겹치는 상황입니다. 프로토콜이나 상위 클래스로 추상화할지 아니면 하나의 구체타입을 만들고 사용하지 않을 수 있는 속성은 옵셔널 처리할지 고민됩니다. 내일 구조 잡으면서 이것도 해결하면 좋을 것 같습니다.
- 현재 TokenViewModel에서 Token 속성을 @Published로 가지고 있습니다. 그런데 Tokens 데이터를 전역으로 관리한다면 이러한 속성이 필요 없어 보입니다. TokenCellView를 띄울 때 전역으로 가지고 있는 Tokens로 부터 필요한 데이터만 받아서 각각 Published 속성으로 할당해주면 될 것 같습니다. 현재 메인 셀 뷰가 그런 형태인데, MainCellViewModel과 TokenViewModel의 중복을 없애면서 token 속성을 가지지 않는 새로운 token cell viewModel을 구성해보면 어떨까 생각해보았습니다. 
- TimeGenerator를 추가했는데, TimeGenerator class를 사용할지 String extension으로 사용할지 고민하다가 기능의 분류가 명확했으면 좋겠다고 생각하여 class로 작성했습니다.
- TimeGenerator 테스트 코드를 추가했는데, 아직 테스트 케이스가 더 필요해 보입니다. 틈틈히 추가하겠습니다.
- TOTP 알고리즘을 직접 구현해보고 싶었는데, 아직 앱에 적용하기에는 이해가 부족합니다. 다음 주에 코어 타임이 끝나고 틈틈히 학습하고 정리해서 swift로 우리만의 TOTP 알고리즘을 구현할 수 있게 해보겠습니다. 
- 원래 MainViewModel에서 fetchToken할 때 더미 데이터를 생성해주었었는데, 이 부분을 Token 구조체로 옮겼습니다. 

```swift
func fetchTokens() {
    tokens = Token.dummy().map {
        TokenViewModel(token: $0)
    }
}
```