### PR TITLE
[BE] csrf header 방어 적용

### DIFF
--- a/WEB/BE/app.js
+++ b/WEB/BE/app.js
@@ -7,6 +7,7 @@ const cors = require('cors');
 const debug = require('debug')('server:server');
 const authRouter = require('@routes/auth');
 const userRouter = require('@routes/user');
+const csrf = require('@middlewares/csrf');
 const sequelizeWEB = require('./models/sequelizeIOS').sequelize;
 const sequelizeIOS = require('./models/sequelizeWEB').sequelize;
 
@@ -27,6 +28,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(dev ? cors() : cors(corsOptions));
+app.use(csrf.checkHeader);
 
 app.use('/api/auth', authRouter);
 app.use('/api/user', userRouter);

--- a/WEB/BE/middlewares/csrf.js
+++ b/WEB/BE/middlewares/csrf.js
@@ -1,17 +1,23 @@
 const createError = require('http-errors');
 
+const dev = process.env.NODE_ENV !== 'production';
+const CUSTOM_CSRF_HEADER = 'X-CSRF';
+const ORIGIN_HEADER_REGEX = dev ? /^http:\/\/localhost:8080/ : /^https:\/\/dadaikseon\.com/;
+const UNAUTHORIZED = 401;
+const CSRF_ERROR_MSG = 'CSRF Attack!';
+
 const csrf = {
   checkHeader(req, res, next) {
-    const csrfHeader = req.headers['X-CSRF'] || req.headers['x-csrf'];
+    const csrfHeader = req.headers[CUSTOM_CSRF_HEADER] || req.headers[CUSTOM_CSRF_HEADER.toLocaleLowerCase()];
 
     const originHeader = req.headers.origin;
-    const isValidOrigin = originHeader && /^(http|https):\/\/dadaikseon\.com/.test(originHeader);
+    const isValidOrigin = originHeader && ORIGIN_HEADER_REGEX.test(originHeader);
 
-    const referrerHeader = req.headers.referer;
-    const isValidReferrer = referrerHeader && /^(http|https):\/\/dadaikseon\.com/.test(originHeader);
+    const refererHeader = req.headers.referer;
+    const isValidReferrer = refererHeader && ORIGIN_HEADER_REGEX.test(refererHeader);
 
     if (!csrfHeader || (!isValidOrigin && !isValidReferrer)) {
-      return next(createError(401));
+      return next(createError(UNAUTHORIZED, CSRF_ERROR_MSG));
     }
 
     return next();

--- a/WEB/FE/src/api/index.tsx
+++ b/WEB/FE/src/api/index.tsx
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+axios.defaults.headers['X-CSRF'] = 'X-CSRF';
+
 interface UserInfo {
   id: string;
   password: string;


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- csrf.js의 checkHeader 미들웨어 수정
  - dev, prod 환경에서 다르게 동작하도록 지정
  - 버그 수정
- axios의 default header로 커스텀 헤더 전송하도록 추가

## :hammer: 변경로직

- 개발환경에서도 csrf 헤더는 체크하도록 설정했습니다.
  - localhost:8080 이 아니라면 401에러가 반환됩니다.
