### PR TITLE
[iOS] 큐알 코드 인식 성공시 편집 화면 표시

### DIFF
--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
@@ -14,7 +14,7 @@ struct DaDaIkSeonApp: App {
     
     var body: some Scene {
         WindowGroup {
-            MainView(service: service)
+            MainView(service: service).environmentObject(NavigationFlowObject())
         }
     }
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/Services/TokenService.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/Services/TokenService.swift
@@ -55,8 +55,10 @@ final class TokenService: TokenServiceable {
     }
     
     func updateMainTokenIndex(id: UUID) {
+        let lastMainIndex = mainTokenIndex
         if let index = tokens.firstIndex(where: { $0.id == id }) {
             mainTokenIndex = index
+            tokens.insert(tokens.remove(at: lastMainIndex), at: 0)
         }
     }
     

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainView.swift
@@ -88,7 +88,7 @@ struct MainView: View {
                         }
                         viewModel.state.isSearching ?
                             nil : NavigationLink(
-                                destination: QRGuideView()
+                                destination: QRGuideView(service: viewModel.state.service)
                                     .environmentObject(navigationFlow),
                                 isActive: $navigationFlow.isActive,
                                 label: {

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/MainView.swift
@@ -33,7 +33,6 @@ struct MainView: View {
     
     // MARK: Property
     
-    @State var isShowEditView = false
     @EnvironmentObject var navigationFlow: NavigationFlowObject
     
     var columns: [GridItem] = [
@@ -115,17 +114,6 @@ struct MainView: View {
         .onTapGesture {
             hideKeyboard()
         }
-        .sheet(
-            isPresented: $isShowEditView,
-            onDismiss: {
-                //viewModel.trigger(.)
-                // refresh 라는 걸 만들어야 할까?
-                // editview에서 변경한 서비스를 반영하기 위해?
-                // 아니야 그냥 뷰모델 넘겨서 뷰모델을 수정해버리자?
-            }, content: {
-                TokenEditView()
-            }
-        )
     }
 }
 

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/QRGuideView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/QRGuideView.swift
@@ -11,9 +11,10 @@ import CodeScanner
 struct QRGuideView: View {
     
     // MARK: Property
-    @State var isShownScanner = false
-    @State var isShownEditView: Bool = false
-    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    private(set) var service: TokenServiceable
+    @State private var isShownScanner = false
+    @State private var isShownEditView: Bool = false
+    @Environment(\.presentationMode) private var mode: Binding<PresentationMode>
     
     // MARK: Body
     var body: some View {
@@ -32,7 +33,10 @@ struct QRGuideView: View {
             .frame(maxWidth: .infinity, maxHeight: 46)
             .background(Color(.systemGray6))
             .cornerRadius(15)
-            NavigationLink("", destination: TokenEditView(), isActive: $isShownEditView)
+            NavigationLink(
+                "",
+                destination: TokenEditView(),
+                isActive: $isShownEditView)
         }
         .padding(.horizontal, 40)
         .navigationBarHidden(false)
@@ -46,7 +50,7 @@ struct QRGuideView: View {
             })
         )
         .sheet(isPresented: $isShownScanner) {
-                QRScannerView(isShownEditView: $isShownEditView)
+            QRScannerView(isShownEditView: $isShownEditView)
         }
         
     }
@@ -55,7 +59,7 @@ struct QRGuideView: View {
 struct QRScannerView: View {
     
     @Binding var isShownEditView: Bool
-    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    @Environment(\.presentationMode) private var mode: Binding<PresentationMode>
     
     var body: some View {
         VStack {
@@ -77,6 +81,6 @@ struct QRScannerView: View {
 // MARK: Preview
 struct QRGuideView_Previews: PreviewProvider {
     static var previews: some View {
-        QRGuideView()
+        QRGuideView(service: TokenService())
     }
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/QRGuideView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/QRGuideView.swift
@@ -59,7 +59,7 @@ struct QRGuideView: View {
 struct QRScannerView: View {
     
     @Binding var isShownEditView: Bool
-    @Environment(\.presentationMode) private var mode: Binding<PresentationMode>
+    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     var body: some View {
         VStack {

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/QRGuideView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/QRGuideView.swift
@@ -11,7 +11,8 @@ import CodeScanner
 struct QRGuideView: View {
     
     // MARK: Property
-    @State var showingScanner = false
+    @State var isShownScanner = false
+    @State var isShownEditView: Bool = false
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     // MARK: Body
@@ -19,19 +20,19 @@ struct QRGuideView: View {
         
         VStack {
             Spacer()
-            
-            NavigationLink(
-                destination: QRScannerView(showingScanner: .constant(showingScanner)),
-                label: {
-                    HStack {
-                        Image(systemName: "camera.fill")
-                        Text("QR 코드 스캔")
-                    }
-                    .foregroundColor(.black)
-                })
-                .frame(maxWidth: .infinity, maxHeight: 46)
-                .background(Color(.systemGray6))
-                .cornerRadius(15)
+            Button(action: {
+                isShownScanner = true
+            }, label: {
+                HStack {
+                    Image(systemName: "camera.fill")
+                    Text("QR 코드 스캔")
+                }
+                .foregroundColor(.black)
+            })
+            .frame(maxWidth: .infinity, maxHeight: 46)
+            .background(Color(.systemGray6))
+            .cornerRadius(15)
+            NavigationLink("", destination: TokenEditView(), isActive: $isShownEditView)
         }
         .padding(.horizontal, 40)
         .navigationBarHidden(false)
@@ -41,31 +42,33 @@ struct QRGuideView: View {
             leading: Button(action: {
                 mode.wrappedValue.dismiss()
             }, label: {
-                Text("취소")
-                    .foregroundColor(.black)
+                Text("취소").foregroundColor(.black)
             })
         )
+        .sheet(isPresented: $isShownScanner) {
+                QRScannerView(isShownEditView: $isShownEditView)
+        }
+        
     }
-    
 }
 
 struct QRScannerView: View {
     
-    @Binding var showingScanner: Bool
+    @Binding var isShownEditView: Bool
+    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     var body: some View {
-        CodeScannerView(codeTypes: [.qr], simulatedData: "-") { result in
-            switch result {
-            case .success(let code):
-                
-                // 여기서 성공하면 새로운 화면 띄운다.
-                // 키값도 넘겨준다.
-                
-                print(code)
-            case .failure(let error):
-                print(error)
+        VStack {
+            CodeScannerView(codeTypes: [.qr], simulatedData: "-") { result in
+                switch result {
+                case .success(let code):
+                    isShownEditView = true
+                    print(code)
+                case .failure(let error):
+                    print(error)
+                }
+                mode.wrappedValue.dismiss()
             }
-            showingScanner = false
         }
     }
     

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
@@ -47,7 +47,8 @@ struct TokenCellView: View {
             VStack {
                 TopButtonViews(
                     action: {
-                        self.viewModel.trigger(.showEditView)
+                        viewModel.trigger(.showEditView)
+                        isShownEditView = true
                     },
                     isShownEditView: $isShownEditView)
                 Spacer()

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
@@ -14,6 +14,11 @@ struct TokenEditView: View {
     @State private var segmentedMode = 0
     @EnvironmentObject var navigationFlow: NavigationFlowObject
     
+    // TokenEditView에 들어갈 아이들
+    //var qrcode: String? // 추가 모드일 때만 필요
+    //var tokenId: UUID? // 편집 모드일 때만 필요
+    //var service: TokenService?
+    
     var body: some View {
         VStack {
             Spacer()

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
@@ -84,9 +84,7 @@ struct TokenEditView: View {
                 })
             )
         }
-//        .onTapGesture {
-//            hideKeyboard()
-//        }
+
     }
 }
 

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
@@ -12,80 +12,76 @@ struct TokenEditView: View {
     @State var isEditing = false
     @State var text = ""
     @State private var segmentedMode = 0
-    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    @EnvironmentObject var navigationFlow: NavigationFlowObject
     
     var body: some View {
-        NavigationView {
-            VStack {
-                Spacer()
-                Image(systemName: "magnifyingglass")
-                    .resizable()
-                    .aspectRatio(1.0, contentMode: .fit)
-                    .frame(minWidth: 20,
-                           maxWidth: 80,
-                           minHeight: 20,
-                           maxHeight: 80)
-                    .padding(60)
-                    .background(LinearGradient.mint)
-                    .foregroundColor(.white)
-                    .cornerRadius(15)
-                
-                TextField("토큰 이름을 입력하세요", text: $text)
-                    .padding(7)
-                    .padding(.horizontal, 25)
-                    .cornerRadius(8)
-                    .overlay(
-                        HStack {
-                            Image(systemName: "pencil.and.outline")
-                                .foregroundColor(.gray)
-                                .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
-                                .padding(.leading, 8)
-                        }
-                    )
-                    .padding(.top, 20)
-                    .padding(.bottom, -8)
-                    .padding(.horizontal, 40)
-                
-                Divider()
-                    .padding(.horizontal, 60)
-                
-                Spacer()
-                
-                Picker(selection: $segmentedMode, label: Text("mode")) {
-                    Text("색상").tag(0)
-                    Text("아이콘").tag(1)
-                }
-                .pickerStyle(SegmentedPickerStyle())
+        VStack {
+            Spacer()
+            Image(systemName: "magnifyingglass")
+                .resizable()
+                .aspectRatio(1.0, contentMode: .fit)
+                .frame(minWidth: 20,
+                       maxWidth: 80,
+                       minHeight: 20,
+                       maxHeight: 80)
+                .padding(60)
+                .background(LinearGradient.mint)
+                .foregroundColor(.white)
+                .cornerRadius(15)
+            
+            TextField("토큰 이름을 입력하세요", text: $text)
+                .padding(7)
+                .padding(.horizontal, 25)
+                .cornerRadius(8)
+                .overlay(
+                    HStack {
+                        Image(systemName: "pencil.and.outline")
+                            .foregroundColor(.gray)
+                            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 8)
+                    }
+                )
+                .padding(.top, 20)
+                .padding(.bottom, -8)
+                .padding(.horizontal, 40)
+            
+            Divider()
                 .padding(.horizontal, 60)
-                
-                Spacer()
-                
-                segmentedMode == 0 ? PaletteView() : nil
-                segmentedMode == 1 ? IconView() : nil
-                
-                Spacer()
+            
+            Spacer()
+            
+            Picker(selection: $segmentedMode, label: Text("mode")) {
+                Text("색상").tag(0)
+                Text("아이콘").tag(1)
             }
-            .padding(.horizontal, 40)
-            .navigationBarHidden(false)
-            .navigationBarTitle("토큰 수정", displayMode: .inline)
-            .navigationBarBackButtonHidden(true)
-            .navigationBarItems(
-                leading: Button(action: {
-                    mode.wrappedValue.dismiss()
-                }, label: {
-                    Text("취소")
-                        .foregroundColor(.black)
-                }),
-                trailing: Button(action: {
-                    mode.wrappedValue.dismiss()
-                }, label: {
-                    Text("저장")
-                        .foregroundColor(.black)
-                })
-            )
+            .pickerStyle(SegmentedPickerStyle())
+            .padding(.horizontal, 60)
+            
+            Spacer()
+            
+            segmentedMode == 0 ? PaletteView() : nil
+            segmentedMode == 1 ? IconView() : nil
+            
+            Spacer()
         }
-
+        .padding(.horizontal, 40)
+        .navigationBarHidden(false)
+        .navigationBarTitle("토큰 수정", displayMode: .inline)
+        .navigationBarBackButtonHidden(true)
+        .navigationBarItems(
+            leading: Button(action: {
+                navigationFlow.isActive = false
+            }, label: {
+                Text("취소").foregroundColor(.black)
+            }),
+            trailing: Button(action: {
+                navigationFlow.isActive = false
+            }, label: {
+                Text("저장").foregroundColor(.black)
+            })
+        )
     }
+    
 }
 
 struct IconView: View {


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 큐알 코드 인식에 성공했을 때 편집 화면 표시

## :hammer: 변경로직

- TokenEditView의 종료 방법을 변경하였습니다. 원래 mode 변수를 사용하여 dismiss를 했었습니다. 이제는 rootView로 바로 이동할 수 있게 하기 위해 NavigationFlow라는 environmentObject를 사용하여 isActive 값을 false로 만들어줌으로써 메인 뷰로 바로 이동되도록 변경하였습니다. 
