### PR TITLE
[BE] 외부 lib없이 TOTP 미들웨어 구현

### DIFF
--- a/WEB/BE/controllers/user/index.js
+++ b/WEB/BE/controllers/user/index.js
@@ -1,9 +1,9 @@
-const speakeasy = require('speakeasy');
 const authService = require('@services/auth');
 const userService = require('@services/user');
 const { encryptWithAES256, decryptWithAES256 } = require('@utils/crypto');
 const { getEncryptedPassword } = require('@utils/bcrypt');
 const { emailSender } = require('@utils/email');
+const totp = require('@utils/totp');
 
 const userController = {
   async signUp(req, res, next) {
@@ -17,8 +17,8 @@ const userController = {
 
     try {
       userInfo = encrypUserInfo({ userInfo });
-      const secretKey = makeSecretKey();
-      const url = makeURL({ secretKey });
+      const secretKey = totp.makeSecretKey();
+      const url = totp.makeURL({ secretKey, email: req.body.email });
       const encryptPassword = await getEncryptedPassword(password);
       const insertResult = await userService.insert({ userInfo, next });
       const result = await authService.insert({
@@ -26,7 +26,7 @@ const userController = {
         id,
         password: encryptPassword,
         state: '0',
-        secretKey: secretKey.base32,
+        secretKey,
         next,
       });
       emailSender.SignUpAuthentication(req.body.email, req.body.name, insertResult.dataValues.idx);
@@ -92,24 +92,6 @@ const encrypUserInfo = ({ userInfo }) => {
     userInfo[key] = encryptWithAES256({ Text: userInfo[key] });
   });
   return userInfo;
-};
-
-const makeSecretKey = () => {
-  const secretKey = speakeasy.generateSecret({
-    length: 20,
-    name: process.env.SECRETKEYNAME,
-    algorithm: process.env.SECRETKEYALGORITHM,
-  });
-  return secretKey;
-};
-
-const makeURL = ({ secretKey }) => {
-  const url = speakeasy.otpauthURL({
-    secret: secretKey.ascii,
-    issuer: 'TOTP',
-    label: process.env.SECRETKEYLABEL,
-  });
-  return url;
 };
 
 module.exports = userController;

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -1,0 +1,15 @@
+const crypto = require('crypto');
+const speakeasy = require('speakeasy');
+
+const totp = {
+  makeSecretKey() {
+    const secretKey = speakeasy.generateSecret({
+      length: 20,
+      name: process.env.SECRETKEYNAME,
+      algorithm: process.env.SECRETKEYALGORITHM,
+    });
+    return secretKey;
+  },
+};
+
+module.exports = totp;

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -17,6 +17,12 @@ const totp = {
   },
 };
 
-const makeSixDigits = (key, date) => {};
+const makeSixDigits = (key, date) => {
+  const timeStmap = makeTimeStamp(date);
+};
+
+const makeTimeStamp = (date, window = 0) => {
+  return Math.floor(new Date(date) / 30000) + window;
+};
 
 module.exports = totp;

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -10,6 +10,10 @@ const totp = {
     });
     return secretKey;
   },
+
+  makeURL({ secretKey, email }) {
+    return `otpauth://totp/${process.env.SECRETKEYLABEL}?secret=${secretKey}&issuer=${email}`;
+  },
 };
 
 module.exports = totp;

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -23,6 +23,9 @@ const makeSixDigits = (key, date) => {
   const buffer = makeBuffer(timeStmap);
   const hash = crypto.createHmac('sha1', key).update(buffer).digest('hex');
   const DBC = selectDBC(hash);
+  let sixDigits = (parseInt(DBC, 16) % 1000000).toString();
+  sixDigits = sixDigits.length !== 6 ? `0${sixDigits}` : sixDigits;
+  return sixDigits;
 };
 
 const makeTimeStamp = (date, window = 0) => {

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -12,6 +12,7 @@ const totp = {
   },
 
   verifyDigits(key, digits, date = new Date()) {
+    key = base32.decode(key);
     const sixDigits = makeSixDigits(key, date);
     return digits === sixDigits;
   },
@@ -20,6 +21,8 @@ const totp = {
 const makeSixDigits = (key, date) => {
   const timeStmap = makeTimeStamp(date);
   const buffer = makeBuffer(timeStmap);
+  const hash = crypto.createHmac('sha1', key).update(buffer).digest('hex');
+  const DBC = selectDBC(hash);
 };
 
 const makeTimeStamp = (date, window = 0) => {
@@ -33,6 +36,14 @@ const makeBuffer = (timeStmap) => {
     timeStmap >>= 8;
   }
   return buffer;
+};
+
+const selectDBC = (hash) => {
+  const offset = parseInt(`${hash.charAt(hash.length - 1)}`, 16);
+  let DBC = hash.slice(offset * 2, offset * 2 + 8);
+  const firstByte = (0x7f & parseInt(DBC.slice(0, 2), 16)).toString(16);
+  DBC = firstByte + DBC.slice(2);
+  return DBC;
 };
 
 module.exports = totp;

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -1,14 +1,10 @@
 const crypto = require('crypto');
-const speakeasy = require('speakeasy');
+const base32 = require('hi-base32');
 
 const totp = {
-  makeSecretKey() {
-    const secretKey = speakeasy.generateSecret({
-      length: 20,
-      name: process.env.SECRETKEYNAME,
-      algorithm: process.env.SECRETKEYALGORITHM,
-    });
-    return secretKey;
+  makeSecretKey(length = 20) {
+    const secretKey = crypto.randomBytes(length);
+    return base32.encode(secretKey).replace(/=/g, '');
   },
 
   makeURL({ secretKey, email }) {

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -19,10 +19,20 @@ const totp = {
 
 const makeSixDigits = (key, date) => {
   const timeStmap = makeTimeStamp(date);
+  const buffer = makeBuffer(timeStmap);
 };
 
 const makeTimeStamp = (date, window = 0) => {
   return Math.floor(new Date(date) / 30000) + window;
+};
+
+const makeBuffer = (timeStmap) => {
+  const buffer = Buffer.alloc(8);
+  for (let i = 0; i < 8; i++) {
+    buffer[7 - i] = timeStmap & 0xff;
+    timeStmap >>= 8;
+  }
+  return buffer;
 };
 
 module.exports = totp;

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -10,6 +10,13 @@ const totp = {
   makeURL({ secretKey, email }) {
     return `otpauth://totp/${process.env.SECRETKEYLABEL}?secret=${secretKey}&issuer=${email}`;
   },
+
+  verifyDigits(key, digits, date = new Date()) {
+    const sixDigits = makeSixDigits(key, date);
+    return digits === sixDigits;
+  },
 };
+
+const makeSixDigits = (key, date) => {};
 
 module.exports = totp;


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 기존에 있던 Totp관련 함수들( makeSecret, makeURL ) 들을 utils/totp 모듈에서 totp를 호출하여 사용할 수 있도록 하였습니다.
- Secret Key를 만들 때 speakeasy API를 사용하였지만, crypto를 사용하여 Secret Key를 만들도록 변경하였고 base32로 인코딩하여 다른 곳들에서 사용이 되도록 하였습니다.
- TOTP 6자리를 검증하는 함수를 미들웨어 사용없이 구현하여 totp에 추가하였습니다.
- 만드는 방식은 wiki 에 정리 하도록 하겠습니다 !

## :hammer: 변경로직

```javascript
const totp = require('@utils/totp');
totp.makeSecretKey(length=20);
totp.makeURL({ secretKey, email });
totp.verifyDigits(key, digits, date= new Date());
```
위와 같이 사용하면 되고 '=' 이 포함되어 있는 것들은 default 값이 있는 것들입니다.

## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #105