### PR TITLE
[FE] 로그인 api 응답 처리

### DIFF
--- a/WEB/FE/src/api/index.tsx
+++ b/WEB/FE/src/api/index.tsx
@@ -64,8 +64,19 @@ interface loginParams {
   reCaptchaToken: string;
 }
 
-export const login = async ({ id, password, reCaptchaToken }: loginParams): Promise<any> => {
-  const { data } = await axios.post('/api/auth', { id, password, reCaptchaToken });
+export const loginWithPassword = async (params: loginParams): Promise<any> => {
+  const { data } = await axios.post('/api/auth', params);
+  return data;
+};
+
+interface loginWithOTPParams {
+  authToken: string;
+  totp: string;
+  reCaptchaToken: string;
+}
+
+export const loginWithOTP = async (params: loginWithOTPParams): Promise<any> => {
+  const { data } = await axios.put('/api/auth', params);
   return data;
 };
 

--- a/WEB/FE/src/components/LogIn/LogInContainer.tsx
+++ b/WEB/FE/src/components/LogIn/LogInContainer.tsx
@@ -1,26 +1,61 @@
 import React, { useState } from 'react';
 import { LogInForm } from '@components/LogIn/LogInForm';
 import { TOTPModal } from '@components/TOTPModal/TOTPModal';
+import { loginWithOTP } from '@api/index';
+import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
+import { useHistory } from 'react-router-dom';
+
+const TOTP_LEN = 6;
 
 interface LogInContainerProps {}
 
 const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
+  const history = useHistory();
+  const { executeRecaptcha } = useGoogleReCaptcha();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [TOTP, setTOTP] = useState('');
+  const [authToken, setAuthToken] = useState('');
+  const [hasTOTPModalError, setHasTOTPModalError] = useState(false);
+  const [modalDisabled, setModalDisabled] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
 
-  const onSuccessLogIn = () => setIsModalOpen(true);
-  const onCloseModal = () => setIsModalOpen(false);
-  const onSubmitOTP = () => {};
+  const onSuccessLogInWithPassword = (authToken: string) => {
+    setAuthToken(authToken);
+    setIsModalOpen(true);
+  };
+  const onCloseModal = () => {
+    setTOTP('');
+    setIsModalOpen(false);
+  };
+  const onErrorWithOTP = (errMsg: string) => {
+    setHasTOTPModalError(true);
+    setErrorMsg(errMsg);
+  };
+  const onSubmitOTP = () => {
+    if (TOTP.length < TOTP_LEN) {
+      onErrorWithOTP('전부 입력해 주세요~');
+      return;
+    }
+    setModalDisabled(true);
+    executeRecaptcha('LogInWithOTP')
+      .then((reCaptchaToken: string) => loginWithOTP({ authToken, totp: TOTP, reCaptchaToken }))
+      .then(() => history.replace('/'))
+      .catch((err: any) => onErrorWithOTP(err.response?.data?.message || err.message))
+      .finally(() => setModalDisabled(false));
+  };
 
   return (
     <>
-      <LogInForm onSuccess={onSuccessLogIn} />
+      <LogInForm onSuccess={onSuccessLogInWithPassword} />
       <TOTPModal
         isOpen={isModalOpen}
         TOTP={TOTP}
         onChange={setTOTP}
         onSubmit={onSubmitOTP}
         onClose={onCloseModal}
+        hasErrored={hasTOTPModalError}
+        disabled={modalDisabled}
+        errorMsg={errorMsg}
       />
     </>
   );

--- a/WEB/FE/src/components/LogIn/LogInContainer.tsx
+++ b/WEB/FE/src/components/LogIn/LogInContainer.tsx
@@ -32,6 +32,7 @@ const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
     setErrorMsg(errMsg);
   };
   const onSubmitOTP = () => {
+    setHasTOTPModalError(false);
     if (TOTP.length < TOTP_LEN) {
       onErrorWithOTP('전부 입력해 주세요~');
       return;

--- a/WEB/FE/src/components/LogIn/LogInForm.tsx
+++ b/WEB/FE/src/components/LogIn/LogInForm.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { AuthForm } from '@components/common/AuthForm';
 import DefaultInput from '@components/common/Input/DefaultInput';
-import { login } from '@api/index';
+import { loginWithPassword } from '@api/index';
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 import { useInput } from '@hooks/useInput';
 
 interface LogInFormProps {
-  onSuccess: () => any;
+  onSuccess: (authToken: string) => any;
 }
 
 const LogInForm = ({ onSuccess }: LogInFormProps): JSX.Element => {
@@ -18,10 +18,10 @@ const LogInForm = ({ onSuccess }: LogInFormProps): JSX.Element => {
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     setIsSubmitting(true);
     e.preventDefault();
-    executeRecaptcha('LogIn')
-      .then((reCaptchaToken: string) => login({ id, password, reCaptchaToken }))
-      .then((result) => onSuccess(result.id))
-      .catch((err) => alert(err.response?.data?.message || err.message))
+    executeRecaptcha('LogInWithPassword')
+      .then((reCaptchaToken: string) => loginWithPassword({ id, password, reCaptchaToken }))
+      .then(({ authToken }: { authToken: string }) => onSuccess(authToken))
+      .catch((err: any) => alert(err.response?.data?.message || err.message))
       .finally(() => setIsSubmitting(false));
   };
 

--- a/WEB/FE/src/components/TOTPModal/TOTPModal.tsx
+++ b/WEB/FE/src/components/TOTPModal/TOTPModal.tsx
@@ -12,6 +12,9 @@ interface TOTPModalProps {
   onChange: (otp: string) => any | React.Dispatch<React.SetStateAction<string>> | undefined;
   onSubmit: () => any;
   onClose: () => void;
+  hasErrored?: boolean;
+  disabled?: boolean;
+  errorMsg?: string | undefined;
 }
 
 const Title = styled.h1`
@@ -26,6 +29,15 @@ const Description = styled.p`
   font-weight: ${({ theme }) => theme.fontWeight.regular};
   text-align: center;
   margin-bottom: 3rem;
+  position: relative;
+`;
+
+const Error = styled.span`
+  color: ${({ theme }) => theme.color.danger};
+  display: block;
+  width: 100%;
+  position: absolute;
+  bottom: -32px;
 `;
 
 const ButtonContainer = styled.div`
@@ -48,13 +60,29 @@ const InputStyle: CSS.Properties = {
   border: '1px solid #ccc',
 };
 
-const TOTPModal = ({ isOpen, TOTP, onChange, onSubmit, onClose }: TOTPModalProps): JSX.Element => {
+const ErrorStyle: CSS.Properties = {
+  border: '1px solid #ff4d4f',
+};
+
+const TOTPModal = ({
+  isOpen,
+  TOTP,
+  onChange,
+  onSubmit,
+  onClose,
+  hasErrored,
+  disabled,
+  errorMsg,
+}: TOTPModalProps): JSX.Element => {
   return (
     <>
       {isOpen ? (
         <Modal>
           <Title>OTP 인증</Title>
-          <Description>표시된 OTP 6자리를 입력해 주세요</Description>
+          <Description>
+            표시된 OTP 6자리를 입력해 주세요
+            {hasErrored && <Error>{errorMsg}</Error>}
+          </Description>
           <OtpInput
             value={TOTP}
             onChange={onChange}
@@ -62,10 +90,18 @@ const TOTPModal = ({ isOpen, TOTP, onChange, onSubmit, onClose }: TOTPModalProps
             inputStyle={InputStyle}
             isInputNum
             shouldAutoFocus
+            hasErrored={hasErrored}
+            errorStyle={ErrorStyle}
+            isDisabled={disabled}
           />
           <ButtonContainer>
-            <Button text='확인' onClick={onSubmit} style={{ padding: '0 4rem', marginRight: '1rem' }} />
-            <Button text='취소' onClick={onClose} type='text' />
+            <Button
+              text='확인'
+              onClick={onSubmit}
+              style={{ padding: '0 4rem', marginRight: '1rem' }}
+              disabled={disabled}
+            />
+            <Button text='취소' onClick={onClose} type='text' disabled={disabled} />
             <br />
             <Link to='/'>QR코드 재등록</Link>
           </ButtonContainer>
@@ -75,6 +111,12 @@ const TOTPModal = ({ isOpen, TOTP, onChange, onSubmit, onClose }: TOTPModalProps
       )}
     </>
   );
+};
+
+TOTPModal.defaultProps = {
+  hasErrored: false,
+  disabled: false,
+  errorMsg: undefined,
 };
 
 export { TOTPModal };

--- a/WEB/FE/src/components/common/Modal.tsx
+++ b/WEB/FE/src/components/common/Modal.tsx
@@ -41,7 +41,7 @@ const ModalContainer = styled.div`
   background-color: ${({ theme }) => theme.color.White};
   border-radius: 4px;
   margin-bottom: 5%;
-  animation: ${boxFade} 0.2s;
+  animation: ${boxFade} 0.3s;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1), 0 6px 6px rgba(0, 0, 0, 0.14);
 `;
 


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 로그인 api를 loginWithPassword, loginWithOTP 2개로 구현
- 성공 시 메인으로 이동
- 실패 시 에러 표시

![image](https://user-images.githubusercontent.com/40662323/100977969-168a0a80-3585-11eb-848d-28c0f783805d.png)
