### PR TITLE
[BE] TOTP 검증 API 수정

### DIFF
--- a/WEB/BE/controllers/auth/index.js
+++ b/WEB/BE/controllers/auth/index.js
@@ -45,7 +45,7 @@ const authController = {
   },
 
   async logInSuccess(req, res, next) {
-    const { action } = req.body;
+    const { action, id } = req.body;
     if (action !== ACIONS.LOGIN) return next(createError(401, '잘못된 요청입니다'));
     try {
       req.session.key = id;

--- a/WEB/BE/middlewares/verifyJWT.js
+++ b/WEB/BE/middlewares/verifyJWT.js
@@ -8,6 +8,7 @@ const verifyJWT = {
     try {
       const { authToken, totp: digits } = req.body;
       const { id, action } = JWT.verify(authToken, process.env.ENCRYPTIONKEY);
+      req.body.id = id;
       req.body.action = action;
       const secretKey = (await authService.getAuthById({ id })).secret_key;
       const result = totp.verifyDigits(secretKey, digits);

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -54,18 +54,4 @@ const selectDBC = (hash) => {
   return DBC;
 };
 
-const generateSecretASCII = (length, symbols = null) => {
-  const bytes = crypto.randomBytes(length || 32);
-  let set = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-  if (symbols) {
-    set += '!@#$%^&*()<>?/[]{},.:;';
-  }
-
-  let output = '';
-  for (let i = 0, l = bytes.length; i < l; i++) {
-    output += set[Math.floor((bytes[i] / 255.0) * (set.length - 1))];
-  }
-  return output;
-};
-
 module.exports = totp;

--- a/WEB/BE/utils/totp/index.js
+++ b/WEB/BE/utils/totp/index.js
@@ -3,8 +3,13 @@ const base32 = require('hi-base32');
 
 const totp = {
   makeSecretKey(length = 20) {
-    const secretKey = crypto.randomBytes(length).toString('utf-8');
-    return base32.encode(secretKey);
+    const bytes = crypto.randomBytes(length || 32);
+    const set = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
+    let output = '';
+    for (let i = 0, l = bytes.length; i < l; i++) {
+      output += set[Math.floor((bytes[i] / 255.0) * (set.length - 1))];
+    }
+    return base32.encode(output).replace(/=/g, '');
   },
 
   makeURL({ secretKey, email }) {
@@ -47,6 +52,20 @@ const selectDBC = (hash) => {
   const firstByte = (0x7f & parseInt(DBC.slice(0, 2), 16)).toString(16);
   DBC = firstByte + DBC.slice(2);
   return DBC;
+};
+
+const generateSecretASCII = (length, symbols = null) => {
+  const bytes = crypto.randomBytes(length || 32);
+  let set = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
+  if (symbols) {
+    set += '!@#$%^&*()<>?/[]{},.:;';
+  }
+
+  let output = '';
+  for (let i = 0, l = bytes.length; i < l; i++) {
+    output += set[Math.floor((bytes[i] / 255.0) * (set.length - 1))];
+  }
+  return output;
 };
 
 module.exports = totp;


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- Crypto의 경우 결과값을 Buffer로 주기 때문에 Buffer값을 지정된 0 ~ 9, a ~ z 까지의 값으로 변환 시켜주고 Base32로 decode 해주었습니다.
- req.body 에 ID가 없어 에러가 났기 때문에 미들웨어에서 id를 req.body에 추가해줬습니다.

## :hammer: 변경로직

```javascript
makeSecretKey(length = 20) {
    const bytes = crypto.randomBytes(length || 32);
    const set = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
    let output = '';
    for (let i = 0, l = bytes.length; i < l; i++) {
      output += set[Math.floor((bytes[i] / 255.0) * (set.length - 1))];
    }
    return base32.encode(output).replace(/=/g, '');
  },
```
set이라는 지정된 값으로 바뀌도록 변경하였습니다.

## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #25
