### PR TITLE
[iOS] 타이머로 인한 에딧뷰 무한 init 문제 해결

### DIFF
--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
@@ -17,7 +17,7 @@ final class TOTPTimer {
     
     static var shared = TOTPTimer()
     
-    var subscribers = [(TimerPublisher) -> Void]()
+    
     
     let timer: TimerPublisher
     
@@ -27,18 +27,24 @@ final class TOTPTimer {
             .autoconnect()
     }
     
-    func start(subscriber: @escaping (TimerPublisher) -> Void) {
-        subscribers.append(subscriber)
+    var subscribers = [UUID:(TimerPublisher) -> Void]()
+    
+    func start(tokenID: UUID, subscriber: @escaping (TimerPublisher) -> Void) {
+        subscribers.updateValue(subscriber, forKey: tokenID)
         subscriber(timer)
     }
     
     func startAll() { // 클로저에 있는 모든 액션 실행
-        subscribers.forEach { $0(timer) }
+        subscribers.forEach { $0.value(timer) }
         print(subscribers.count)
     }
     
     func cancel() { // 타이머의 upstream을 닫음. 모든 subscriber 구독 중지.
         timer.upstream.connect().cancel()
+    }
+    
+    func deleteSubscriber(tokenID: UUID) {
+        subscribers.removeValue(forKey: tokenID)
     }
     
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
@@ -10,14 +10,16 @@ import Combine
 
 final class TOTPTimer {
     
+    typealias TimerPublisher = Publishers.Autoconnect<Timer.TimerPublisher>
+    
     let totalTime = 30.0
     let timerInterval = 0.01
     
     static var shared = TOTPTimer()
     
-    var subscribers = [(Publishers.Autoconnect<Timer.TimerPublisher>) -> Void]()
+    var subscribers = [(TimerPublisher) -> Void]()
     
-    let timer: Publishers.Autoconnect<Timer.TimerPublisher>
+    let timer: TimerPublisher
     
     private init() {
         timer = Timer
@@ -25,13 +27,14 @@ final class TOTPTimer {
             .autoconnect()
     }
     
-    func start(subscriber: @escaping (Publishers.Autoconnect<Timer.TimerPublisher>) -> Void) {
+    func start(subscriber: @escaping (TimerPublisher) -> Void) {
         subscribers.append(subscriber)
         subscriber(timer)
     }
     
     func startAll() { // 클로저에 있는 모든 액션 실행
         subscribers.forEach { $0(timer) }
+        print(subscribers.count)
     }
     
     func cancel() { // 타이머의 upstream을 닫음. 모든 subscriber 구독 중지.

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
@@ -13,15 +13,29 @@ final class TOTPTimer {
     let totalTime = 30.0
     let timerInterval = 0.01
     
-    let timer: Publishers.Autoconnect<Timer.TimerPublisher>
-    
     static var shared = TOTPTimer()
     
+    var subscribers = [(Publishers.Autoconnect<Timer.TimerPublisher>) -> Void]()
+    
+    let timer: Publishers.Autoconnect<Timer.TimerPublisher>
+    
     private init() {
-        
         timer = Timer
             .publish(every: timerInterval, on: .main, in: .common)
             .autoconnect()
-        
     }
+    
+    func start(subscriber: @escaping (Publishers.Autoconnect<Timer.TimerPublisher>) -> Void) {
+        subscribers.append(subscriber)
+        subscriber(timer)
+    }
+    
+    func startAll() { // 클로저에 있는 모든 액션 실행
+        subscribers.forEach { $0(timer) }
+    }
+    
+    func cancel() { // 타이머의 upstream을 닫음. 모든 subscriber 구독 중지.
+        timer.upstream.connect().cancel()
+    }
+    
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/TOTPTimer.swift
@@ -17,17 +17,15 @@ final class TOTPTimer {
     
     static var shared = TOTPTimer()
     
-    
-    
     let timer: TimerPublisher
+    
+    var subscribers = [UUID: (TimerPublisher) -> Void]()
     
     private init() {
         timer = Timer
             .publish(every: timerInterval, on: .main, in: .common)
             .autoconnect()
     }
-    
-    var subscribers = [UUID:(TimerPublisher) -> Void]()
     
     func start(tokenID: UUID, subscriber: @escaping (TimerPublisher) -> Void) {
         subscribers.updateValue(subscriber, forKey: tokenID)
@@ -36,15 +34,16 @@ final class TOTPTimer {
     
     func startAll() { // 클로저에 있는 모든 액션 실행
         subscribers.forEach { $0.value(timer) }
-        print(subscribers.count)
     }
     
     func cancel() { // 타이머의 upstream을 닫음. 모든 subscriber 구독 중지.
         timer.upstream.connect().cancel()
     }
     
-    func deleteSubscriber(tokenID: UUID) {
-        subscribers.removeValue(forKey: tokenID)
+    func deleteSubscribers(tokenIDs: [UUID]) {
+        tokenIDs.forEach {
+            subscribers.removeValue(forKey: $0)
+        }
     }
     
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView+SubViews.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView+SubViews.swift
@@ -26,6 +26,7 @@ struct TopButtonViews: View {
                     isChecked ?
                         Image(systemName: "checkmark.circle.fill")
                         :Image(systemName: "circle")
+                    // TODO: 이미지 셋에 추가하기 
                 } else {
                     Button(
                         action: { action() },

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
@@ -62,11 +62,10 @@ struct TokenCellView: View {
                     .sheet(isPresented: $viewModel.state.isShownEditView,
                            onDismiss: { viewModel.trigger(.hideEditView) },
                            content: { 
-                               TokenEditView(service: viewModel.state.service, 
-                                             token: viewModel.state.token, 
-                                             qrCode: nil) 
+                            TokenEditView(service: viewModel.state.service,
+                                          token: viewModel.state.token,
+                                          qrCode: nil)
                            })
-                
                 Spacer()
                 
                 if !isMain {

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
@@ -33,12 +33,13 @@ struct TokenCellView: View {
     @Binding var checkBoxMode: Bool
     var isSelected: Bool
     
-    var isMain: Bool
+    var isMainCell: Bool
     
     init(service: TokenServiceable, token: Token,
          isMain: Bool, checkBoxMode: Binding<Bool>, isSelected: Bool?) {
-        viewModel = AnyViewModel(TokenCellViewModel(service: service, token: token))
-        self.isMain = isMain
+        viewModel = AnyViewModel(
+            TokenCellViewModel(service: service, token: token, isMainCell: isMain))
+        self.isMainCell = isMain
         _checkBoxMode = checkBoxMode
         self.isSelected = isSelected ?? false
     }
@@ -68,9 +69,9 @@ struct TokenCellView: View {
                            })
                 Spacer()
                 
-                if !isMain {
+                if !isMainCell {
                     TokenNameView(tokenName: viewModel.state.token.tokenName)
-                    TokenPasswordView(password: viewModel.state.password, isMain: isMain)
+                    TokenPasswordView(password: viewModel.state.password, isMain: isMainCell)
                 } else {
                     CopyButtonView {
                         //mainCellViewModel.copyButtonDidTab()
@@ -81,7 +82,7 @@ struct TokenCellView: View {
             .cornerRadius(15)
             .shadow(color: Color.shadow, radius: 6, x: 0, y: 3.0)
             
-            if isMain {
+            if isMainCell {
                 // MARK: 프로그레스 바
                 CircularProgressBar(
                     progressAmount: viewModel.state.timeAmount,

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenEditView.swift
@@ -32,10 +32,8 @@ struct TokenEditView: View {
     @State private var showingAlert: Bool = false
     
     init(service: TokenServiceable, token: Token?, qrCode: String?) {
-        viewModel = AnyViewModel(TokenEditViewModel(service: service,
-                                                    token: token,
-                                                    qrCode: qrCode))
-        print("token: \(String(describing: token)), qrCode Key : \(String(describing: qrCode))")
+        viewModel = AnyViewModel(
+            TokenEditViewModel(service: service, token: token, qrCode: qrCode))
     }
     
     // MARK: Body

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/MainViewModel.swift
@@ -69,10 +69,11 @@ final class MainViewModel: ViewModel {
                 }
             }
         case .deleteSelectedTokens:
-            state.service.removeTokens(
-                state.selectedTokens
-                    .filter { $0.value == true}
-                    .map { $0.key })
+            let deletedTokens = state.selectedTokens
+                .filter { $0.value == true}
+                .map { $0.key }
+            TOTPTimer.shared.deleteSubscribers(tokenIDs: deletedTokens)
+            state.service.removeTokens(deletedTokens)
             trigger(.hideCheckBox)
             state.selectedCount = 0
             showMainScene()

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
@@ -21,9 +21,12 @@ final class TokenCellViewModel: ViewModel {
     
     var lastSecond: Int = 1
     
+    var isMainCell: Bool
+    
     // MARK: init
     
-    init(service: TokenServiceable, token: Token) {
+    init(service: TokenServiceable, token: Token, isMainCell: Bool) {
+        self.isMainCell = isMainCell
         state = TokenCellState(service: service,
                                token: token,
                                password: TOTPGenerator.generate(from: token.key ?? "") ?? "000000",
@@ -66,16 +69,16 @@ extension TokenCellViewModel {
             })
             .sink { [weak self] (seconds) in
                 guard let `self` = self else { return }
-                `self`.updatePassword(seconds: seconds, key: key)
-                `self`.updateTimeAmount()
+                `self`.momentOfSecondsChanged(seconds: seconds, key: key)
+                if `self`.isMainCell { `self`.updateTimeAmount() }
             }
             .store(in: &`self`.subscriptions)
         }
     }
     
-    func updatePassword(seconds: Int, key: String) {
+    func momentOfSecondsChanged(seconds: Int, key: String) {
         if lastSecond != seconds {
-            leftTime = "\(seconds)"
+            if isMainCell { leftTime = "\(seconds)" }
             if seconds == 0 {
                 password
                     = TOTPGenerator.generate(from: key) ?? "000000"

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
@@ -30,12 +30,9 @@ final class TokenCellViewModel: ViewModel {
                                leftTime: "1",
                                timeAmount: 0.0,
                                isShownEditView: false)
-        timeAmount = countTimeBy30 + 1
-        
         TOTPTimer.shared.start(
             tokenID: token.id,
             subscriber: initTimer(key: token.key ?? ""))
-        
     }
     
     // MARK: Methods
@@ -93,7 +90,7 @@ extension TokenCellViewModel {
     }
     
     func updateTimeAmount() {
-        timeAmount += timerInterval
+        timeAmount = countTimeBy30 + timerInterval
     }
     
     var countTimeBy30: Double {

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
@@ -55,8 +55,7 @@ final class TokenCellViewModel: ViewModel {
 
 extension TokenCellViewModel {
     
-    // key를 TokenCellViewModel의 프로퍼티로 두지 말고 커링으로 timer 시작함수에 넣어놓자.
-    func initTimer(key: String) -> ((Publishers.Autoconnect<Timer.TimerPublisher>) -> Void) {
+    func initTimer(key: String) -> ((TOTPTimer.TimerPublisher) -> Void) {
         return {[weak self] timer in
             guard let `self` = self else { return }
             timer.map({ (output) in

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
@@ -33,6 +33,7 @@ final class TokenCellViewModel: ViewModel {
         timeAmount = countTimeBy30 + 1
         
         TOTPTimer.shared.start(
+            tokenID: token.id,
             subscriber: initTimer(key: token.key ?? ""))
         
     }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
@@ -75,7 +75,7 @@ extension TokenCellViewModel {
     
     func updatePassword(seconds: Int, key: String) {
         if lastSecond != seconds {
-            leftTime = "\(seconds + 1)"
+            leftTime = "\(seconds)"
             if seconds == 0 {
                 password
                     = TOTPGenerator.generate(from: key) ?? "000000"


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 에딧뷰를 sheet로 열 때 타이머 정지
- 돌아올 때 다시 타이머 실행
- 메인뷰에만 필요한 state는 메인뷰일때에만 update하도록 변경
- 남은 초 표시할때 0부터 시작하도록 변경

## :hammer: 변경로직

- 타이머 정지를 위해 cellviemodel에서 타이머를 subscribe하는 클로저를 TOTPTimer에 넘겨줍니다. TOTPTimer는 TokenID를 key로 사용하는 딕셔너리에 해당 클로저를 저장합니다. 클로저를 넘겨줄 때 key는 커링을 사용하여 cellViewModel이 property로 key값을 가지고 있지 않도록 해주었습니다.
- 화면 전환이 시작되면 TOTPTImer의 cancel함수를 호출해줍니다. 이 함수에서는 timer의 upstream을 cancel해줍니다. 
- 모든 타이머가 정지 되었기 때문에 다시 메인 화면에 돌아올 때 모든 셀을 다시 타이머에 등록해주어야 합니다. 이를 위해 TOTPTImer가 startAll함수에서 가지고있는 클로저의 원소들을 돌면서 실행해줍니다.
- 셀을 삭제할 때 타이머에 있는 클로저 삭제를 위해 메인 뷰모델에서 타이머의 deleteSubscribers를 호출해줍니다.

## :camera_flash: 스크린샷 (Optional)

![에딧뷰해결](https://user-images.githubusercontent.com/44443949/101238944-17f33880-3727-11eb-88fd-80685926b1ed.gif)

