### PR TITLE
[iOS] search 중 cell로 돌아갔을 때 TextField 버그 수정

### DIFF
--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/SearchBarView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/SearchBarView.swift
@@ -85,7 +85,12 @@ private extension SearchBarView {
     
     func changeSearchState(changed: Bool) {
         withAnimation {
-            changed ? viewModel.trigger(.startSearch) : viewModel.trigger(.endSearch)
+            if changed {
+                viewModel.trigger(.startSearch)
+            } else {
+                viewModel.trigger(.endSearch)
+                freshSearchBar()
+            }
         }
     }
     
@@ -99,7 +104,6 @@ private extension SearchBarView {
     func endSearch() {
         withAnimation {
             viewModel.trigger(.endSearch)
-            freshSearchBar()
         }
     }
     

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/ViewModel/TokenCellViewModel.swift
@@ -33,9 +33,8 @@ final class TokenCellViewModel: ViewModel {
                                leftTime: "1",
                                timeAmount: 0.0,
                                isShownEditView: false)
-        TOTPTimer.shared.start(
-            tokenID: token.id,
-            subscriber: initTimer(key: token.key ?? ""))
+        TOTPTimer.shared.start(tokenID: token.id,
+                               subscriber: initTimer(key: token.key ?? ""))
     }
     
     // MARK: Methods
@@ -57,22 +56,21 @@ final class TokenCellViewModel: ViewModel {
 extension TokenCellViewModel {
     
     func initTimer(key: String) -> ((TOTPTimer.TimerPublisher) -> Void) {
-        return {[weak self] timer in
-            guard let `self` = self else { return }
+        return { [weak self] timer in
+            guard let self = self else { return }
             timer.map({ (output) in
                 output.timeIntervalSince1970
             })
             .map({ [weak self] (timeInterval) -> Int in
-                guard let `self` = self else { return 0 }
-                return Int(
-                    timeInterval.truncatingRemainder(dividingBy: `self`.totalTime))
+                guard let self = self else { return 0 }
+                return Int(timeInterval.truncatingRemainder(dividingBy: self.totalTime))
             })
             .sink { [weak self] (seconds) in
-                guard let `self` = self else { return }
-                `self`.momentOfSecondsChanged(seconds: seconds, key: key)
-                if `self`.isMainCell { `self`.updateTimeAmount() }
+                guard let self = self else { return }
+                self.momentOfSecondsChanged(seconds: seconds, key: key)
+                if self.isMainCell { self.updateTimeAmount() }
             }
-            .store(in: &`self`.subscriptions)
+            .store(in: &self.subscriptions)
         }
     }
     


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- search 중 cell로 돌아갔을 때 TextField 버그 수정

## :hammer: 변경로직

- endSearch 할 때 무조건 freshSearchBar() 불리게 변경  
- `self` -> self수정
