### PR TITLE
[iOS] Service 키체인 불러오기 버그 수정, 조금 생각해볼 애니메이션 추가

### DIFF
--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
@@ -13,10 +13,10 @@ struct DaDaIkSeonApp: App {
     var body: some Scene {
         
         #if DEBUG
-        
+
         let service = MockTokenService()
-        
-        #elseif !DEBUG
+
+        #else
         
         let storageManager = StorageManager()
         let service = TokenService(storageManager)

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/Services/TokenService.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/Services/TokenService.swift
@@ -23,6 +23,9 @@ final class TokenService: TokenServiceable {
     init(_ storageManager: StorageManager) {
         self.storageManager = storageManager
         tokens = loadTokens()
+        for index in tokens.indices where tokens[index].isMain == true { return }
+        if tokens.count == 0 { return }
+        tokens[0].isMain = true
     }
     
     // MARK: Methods

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Main/View/TokenCellView.swift
@@ -96,6 +96,23 @@ struct TokenCellView: View {
             }
             
         }
+        .modifier( Shake(animatableData: checkBoxMode ?  5 : 0) )
+        
+    }
+}
+
+struct Shake: GeometryEffect {
+    var amount: CGFloat = 3
+    var shakesPerUnit = 3
+    var animatableData: CGFloat
+    
+    var sinValue: CGFloat {
+        sin(animatableData * .pi * CGFloat(shakesPerUnit))
+    }
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform(
+            CGAffineTransform(translationX: amount * sinValue, y: 0))
     }
 }
 


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- Service 키체인 불러오기 버그 수정
- 조금 생각해볼 애니메이션 추가

## :hammer: 변경로직

- 키체인으로 불러왔을 때 isMain에 true가 하나도 없으면 첫번째 token을 메인으로 지정해주었습니다.
- 선택모드 버튼을 누를 때 애니메이션을 추가했습니다. 그런데 생각해보고 고민해보고 다시 한번 생각해볼 필요가 있을 것 같습니다. 

## :camera_flash: 스크린샷 (Optional)

![Dec-06-2020 01-53-57](https://user-images.githubusercontent.com/44443949/101258484-1b59e480-3766-11eb-8b60-ef09df233e92.gif)

## :lock: 관련 이슈(닫을 이슈)

- #52