### PR TITLE
[FE] 로그인페이지, 라우터 변경

### DIFF
--- a/WEB/FE/src/components/App.tsx
+++ b/WEB/FE/src/components/App.tsx
@@ -8,34 +8,15 @@ import { Modal } from './common/Modal';
 
 interface AppProps {}
 
-const Hello = () => (
-  <>
-    <Modal>
-      <Button text={<Link to='/signup'>Sign up</Link>} />
-      <br />
-      <br />
-      <Button text={<Link to='/login'>Log in</Link>} />
-      <br />
-      <br />
-      <Button text={<Link to='/findId'>Find ID</Link>} />
-      <br />
-      <br />
-      <Button text={<Link to='/findPassword'>Find Password?</Link>} />
-      <br />
-      <br />
-    </Modal>
-  </>
-);
-
 const App: React.FC<AppProps> = () => {
   return (
     <>
       <BrowserRouter>
         <Switch>
-          <Route exact path='/' component={Hello} />
+          <Route exact path='/' component={Pages.MyPage} />
+          <Route exact path='/login' component={Pages.LogInPage} />
           <Route exact path='/confirm-email' component={ComfirmEmail} />
           <Route exact path='/signup' component={Pages.SignUpPage} />
-          <Route exact path='/login' component={Pages.LogInPage} />
           <Route exact path='/QRCode/:url' component={Pages.QRCodePage} />
           <Route exact path='/findId' component={Pages.findIDPage} />
           <Route exact path='/findPassword' component={Pages.FindPasswordPage} />

--- a/WEB/FE/src/components/App.tsx
+++ b/WEB/FE/src/components/App.tsx
@@ -13,7 +13,7 @@ const App: React.FC<AppProps> = () => {
     <>
       <BrowserRouter>
         <Switch>
-          <Route exact path='/' component={Pages.MyPage} />
+          <PrivateRoute exact path='/' component={Pages.MyPage} />
           <Route exact path='/login' component={Pages.LogInPage} />
           <Route exact path='/confirm-email' component={ComfirmEmail} />
           <Route exact path='/signup' component={Pages.SignUpPage} />
@@ -21,7 +21,6 @@ const App: React.FC<AppProps> = () => {
           <Route exact path='/findId' component={Pages.findIDPage} />
           <Route exact path='/findPassword' component={Pages.FindPasswordPage} />
           <Route exact path='/changePassword' component={Pages.ChangePasswordPage} />
-          <PrivateRoute path='/me' component={Pages.MyPage} />
           <Route component={Pages.NotFoundPage} />
         </Switch>
       </BrowserRouter>

--- a/WEB/FE/src/components/LogIn/LogInContainer.tsx
+++ b/WEB/FE/src/components/LogIn/LogInContainer.tsx
@@ -57,6 +57,7 @@ const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
   const successLoginHandler = () => {
     alert(message.SIGNINSUCCESS);
     console.log(document.cookie);
+    localStorage.user = 'in';
     history.replace('/');
   };
 

--- a/WEB/FE/src/components/LogIn/LogInContainer.tsx
+++ b/WEB/FE/src/components/LogIn/LogInContainer.tsx
@@ -56,8 +56,7 @@ const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
 
   const successLoginHandler = () => {
     alert(message.SIGNINSUCCESS);
-    console.log(document.cookie);
-    localStorage.user = 'in';
+    localStorage.user = 'login';
     history.replace('/');
   };
 

--- a/WEB/FE/src/components/LogIn/LogInForm.tsx
+++ b/WEB/FE/src/components/LogIn/LogInForm.tsx
@@ -4,6 +4,17 @@ import DefaultInput from '@components/common/Input/DefaultInput';
 import { loginWithPassword } from '@api/index';
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 import { useInput } from '@hooks/useInput';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const TextWrapper = styled.div`
+  text-align: center;
+  margin-top: 4%;
+  a {
+    margin-left: 3%;
+    color: ${({ theme }) => theme.color?.link};
+  }
+`;
 
 interface LogInFormProps {
   onSuccess: (authToken: string) => any;
@@ -27,7 +38,7 @@ const LogInForm = ({ onSuccess }: LogInFormProps): JSX.Element => {
 
   return (
     <AuthForm
-      title='LogIn'
+      title='LOGIN'
       action='/api/auth'
       onSubmit={onSubmit}
       submitButtonText={isSubmitting ? '로그인 중' : '로그인'}
@@ -35,6 +46,16 @@ const LogInForm = ({ onSuccess }: LogInFormProps): JSX.Element => {
     >
       <DefaultInput value={id} type='text' placeholder='ID' onChange={setId} />
       <DefaultInput value={password} type='password' placeholder='Password' onChange={setPassword} />
+      <TextWrapper>
+        <span>계정이 없나요?</span>
+        <span>
+          <Link to='/signup'>회원가입</Link>
+        </span>
+      </TextWrapper>
+      <TextWrapper>
+        <Link to='/findId'>아이디찾기</Link>
+        <Link to='/findPassword'>비밀번호찾기</Link>
+      </TextWrapper>
     </AuthForm>
   );
 };

--- a/WEB/FE/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/WEB/FE/src/components/PrivateRoute/PrivateRoute.tsx
@@ -4,8 +4,7 @@ import { Redirect, Route, RouteProps } from 'react-router-dom';
 interface PrivateRouteProps extends RouteProps {}
 
 const PrivateRoute: React.FC<PrivateRouteProps> = (props) => {
-  /** @TODO 로그인 조건 추가 */
-  const isAuthenticated = true;
+  const isAuthenticated = localStorage.user;
 
   return isAuthenticated ? (
     <Route {...props} />
@@ -16,7 +15,7 @@ const PrivateRoute: React.FC<PrivateRouteProps> = (props) => {
       render={({ location }) => (
         <Redirect
           to={{
-            pathname: '/',
+            pathname: '/login',
             state: { from: location },
           }}
         />

--- a/WEB/FE/src/pages/MyPage.tsx
+++ b/WEB/FE/src/pages/MyPage.tsx
@@ -6,9 +6,6 @@ import { Redirect } from 'react-router-dom';
 interface MyPageProps {}
 
 function MyPage({}: MyPageProps): JSX.Element {
-  if (!localStorage.user) {
-    return <Redirect to='/login' />;
-  }
   return (
     <MainPageLayout>
       <MyPageContainer />

--- a/WEB/FE/src/pages/MyPage.tsx
+++ b/WEB/FE/src/pages/MyPage.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { MainPageLayout } from '@layouts/MainPageLayout';
 import { MyPageContainer } from '@components/MyPage/MyPageContainer';
+import { Redirect } from 'react-router-dom';
 
 interface MyPageProps {}
 
 function MyPage({}: MyPageProps): JSX.Element {
+  if (!localStorage.user) {
+    return <Redirect to='/login' />;
+  }
   return (
     <MainPageLayout>
       <MyPageContainer />


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 로그인페이지에 회원가입, 아이디찾기, 비밀번호 찾기를 추가하였습니다.
- '/' 경로로 이동시에 Mypage로 이동할 수 있도록하였고, 로그인이 되어있지 않다면 로그인을하게 했습니다.

## :hammer: 변경로직

```javascript
const successLoginHandler = () => {
    alert(message.SIGNINSUCCESS);
    localStorage.user = 'login';
    history.replace('/');
  };
```
현재 로그인하게되면 localStorage에 'login'값을 저장하여 localStorage.user값이 존재하면 mypage로 바로 넘어가고 아니면 login으로 redirect 하게 하였습니다. user의 값을 의미있는 값으로 전달하고 싶다면 이름이나 아이디를 response로 넘겨받아야할 것 같습니다 !

<br>

<br>

```javascript
function MyPage({}: MyPageProps): JSX.Element {
  if (!localStorage.user) {
    return <Redirect to='/login' />;
  }
  return (
    <MainPageLayout>
      <MyPageContainer />
    </MainPageLayout>
  );
}
```
redirect관련해서는 react-router v4 이상부터는 history.replace , <Redirect> 를 사용한다는 것을 확인하고 app.js가 지저분해지는 것보다 MyPage 안에서 구분해주는 것이 나을 것 같다는 판단이 들어서 이렇게 구현하였습니다 ! 혹시 문제가 되는 부분이 있으면 알려주시면 감사하겠습니다 ㅎㅎㅎ!
## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #issueNumber
