### PR TITLE
[FE,BE] 세션 에러처리 수정

### DIFF
--- a/WEB/BE/app.js
+++ b/WEB/BE/app.js
@@ -37,7 +37,6 @@ const sessionOptions = {
   saveUninitialized: false,
   resave: true,
   rolling: true,
-  httpOnly: true,
   secret: process.env.SESSIONKEY,
   cookie: {
     maxAge: 7200000,

--- a/WEB/BE/app.js
+++ b/WEB/BE/app.js
@@ -37,6 +37,7 @@ const sessionOptions = {
   saveUninitialized: false,
   resave: true,
   rolling: true,
+  httpOnly: true,
   secret: process.env.SESSIONKEY,
   cookie: {
     maxAge: 7200000,

--- a/WEB/BE/middlewares/sessionAuthentication.js
+++ b/WEB/BE/middlewares/sessionAuthentication.js
@@ -5,7 +5,8 @@ const sessionAuthentication = {
     const { csrfToken } = req.cookies;
     // if (!req.session.key && req.session.CSRF_TOKEN !== CSRFTOKEN) {
     if (!req.session.user) {
-      return next(createError(401, '권한이 없습니다'));
+      res.clearCookie('csrfToken');
+      return next(createError(401, '로그아웃되어 권한이 없습니다.'));
     }
     res.cookie('csrfToken', csrfToken, {
       maxAge: 2 * 60 * 60 * 1000,

--- a/WEB/FE/src/components/MyPage/MyPageContainer.tsx
+++ b/WEB/FE/src/components/MyPage/MyPageContainer.tsx
@@ -115,7 +115,10 @@ function MyPageContainer({}: MyPageContainerProps): JSX.Element {
         setLogs(data.result.rows);
         setMaxPage(Math.ceil(data.result.count / 6));
       })
-      .catch((err: any) => alert('로그를 받아오는데 실패했습니다.'));
+      .catch((err: any) => {
+        alert(`${err.response?.data?.message || err.message} 다시 로그인해주세요.`);
+        localStorage.clear();
+      });
   }, [page]);
 
   return (


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- BE에서 세션이 없을 때 CSRF Token Cookie를 삭제하도록 하였습니다.
- FE에서 세션이 없어 에러가 발생했을 때 메세지 출력을 변경하고 local Storage를 Clear하도록 하였습니다.

## :hammer: 변경로직

- 내용을 적어주세요. (리뷰 할 때 중요한 부분을 적어두도록 합시다.)

## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #240
