### PR TITLE
[FE,BE]로그아웃 (세션, 쿠키, Local Storage) 삭제 구현

### DIFF
--- a/WEB/BE/controllers/web/auth/index.js
+++ b/WEB/BE/controllers/web/auth/index.js
@@ -149,6 +149,15 @@ const authController = {
 
     res.json({ result: true });
   },
+
+  async logout(req, res, next) {
+    req.session.destroy((err) => {
+      if (err) next(createError(err));
+      res.clearCookie('csrfToken');
+      res.clearCookie('connect.sid');
+      res.json({ result: true });
+    });
+  },
 };
 
 const makeLogData = async ({ ip, userAgent, id, sid }) => {

--- a/WEB/BE/routes/web/auth/index.js
+++ b/WEB/BE/routes/web/auth/index.js
@@ -129,6 +129,8 @@ router.put('/secret-key/email', reCAPTCHA.verify, authController.sendSecretKeyEm
 
 router.use(sessionAuthentication.sessionCheck);
 
+router.get('/logout', authController.logout);
+
 router.post('/check-pw', authController.checkPassword);
 
 module.exports = router;

--- a/WEB/FE/src/api/index.tsx
+++ b/WEB/FE/src/api/index.tsx
@@ -155,3 +155,8 @@ export const delSession = async (sid: delSessionParmas): Promise<any> => {
   const { data } = await axios.patch('api/log/session', sid);
   return data;
 };
+
+export const logoutAPI = async (): Promise<any> => {
+  const { data } = await axios.get('api/auth/logout');
+  return data;
+};

--- a/WEB/FE/src/components/common/Header/Header.tsx
+++ b/WEB/FE/src/components/common/Header/Header.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import Button from '@components/common/Button';
 import storageHandler from '@utils/localStorage';
 import { Dropdown } from '@components/common/Header/Dropdown';
 import { Nav } from '@components/common/Header/Nav';
+import { logoutAPI } from '@api/index';
 
 const Wrapper = styled.header`
   width: 100%;
@@ -35,10 +36,18 @@ const AuthContainer = styled.div`
 interface HeaderProps {}
 
 const Header: React.FC<HeaderProps> = () => {
+  const history = useHistory();
   const userName = storageHandler.get();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-  const onLogout = () => {};
+  const onLogout = async () => {
+    await logoutAPI()
+      .then(() => {
+        window.location.reload();
+        localStorage.clear();
+      })
+      .catch((err: any) => alert(err.response?.data?.message || err.message));
+  };
 
   return (
     <Wrapper>

--- a/WEB/FE/src/components/common/Header/Header.tsx
+++ b/WEB/FE/src/components/common/Header/Header.tsx
@@ -36,15 +36,14 @@ const AuthContainer = styled.div`
 interface HeaderProps {}
 
 const Header: React.FC<HeaderProps> = () => {
-  const history = useHistory();
   const userName = storageHandler.get();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const onLogout = async () => {
     await logoutAPI()
       .then(() => {
-        window.location.reload();
         localStorage.clear();
+        window.location.reload();
       })
       .catch((err: any) => alert(err.response?.data?.message || err.message));
   };


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 로그아웃  요청을하면 서버에서 Session 삭제와 동시에 Cookie를 삭제해줬습니다.
- 로그아웃 요청을 처리한 후에 Local Storage를 삭제하고 페이지를 reload하게 하였습니다.

## :hammer: 변경로직

```javascript
req.session.destroy((err) => {
      if (err) next(createError(err));
      res.clearCookie('csrfToken');
      res.clearCookie('connect.sid');
      res.json({ result: true });
    });
```
destroy는 비동기 함수이기 때문에 res.json or res.send 코드가 밖에 있으면
```
[ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
```
에러를 발생시키니 주의..!
## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #248
