### PR TITLE
[iOS] 생체인증 완성, 키체인 삭제 버그 수정

### DIFF
--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
@@ -10,68 +10,68 @@ import SwiftUI
 @main
 struct DaDaIkSeonApp: App {
     
-    @State var main = false
-    @State var pincode = false
-    
-    var pincodeManager = PincodeManager()
-    var bioAuth = BiometricIDAuth()
-    
+    @State var root: DaDaIkSeonAppRootViews = .none
     @Environment(\.scenePhase) var scenePhase
-
+    
     var body: some Scene {
         
-        let storageManager = StorageManager()
-        let service = TokenService(storageManager)
+        let service = TokenService(StorageManager())
         
         WindowGroup {
-            // 아래에서 상태 만들고 여기서 조건문으로 분기
-            
-            // 각 뷰의 상태값을 만듬
-            // 조건문에 따라 다른 뷰 생성
-            
-            if main {
+            switch root {
+            case .main:
                 MainView(service: service).environmentObject(NavigationFlowObject())
-            } else if pincode {
-                if let pincode = pincodeManager.loadPincode() {
+            case .localAuth:
+                if let pincode = PincodeManager().loadPincode() {
                     PinCodeView(mode: .auth(pincode), completion: { _ in
-                        self.pincode = false
-                        main = true
+                        root = .main
                     })
                 }
+            case .networkAuth:
+                EmptyView()
+            case .none:
+                EmptyView()
             }
-            // 대체 화면이 있어야 하나? - 배경을 달아놓을까?
         }
         .onChange(of: scenePhase, perform: { newScenePhrase in
             switch newScenePhrase {
+            case .inactive:
+                DispatchQueue.main.async { root = .none }
             case .active:
-                guard !main && !pincode else { return } // 하나라도 true면 실행 못하게
-                // jwt를 핀코드보다 먼저 검사해야할지 고민
-                if let pincode = pincodeManager.loadPincode() {
-                    bioAuth.authenticateUser { result in
-                        if result == nil { // 생체인증 성공
-                            print("성공")
-                            DispatchQueue.main.async {
-                                main = true
-                            }
-                        } else {
-                            if "You pressed cancel." == result
-                                || "You pressed password." == result {
-                                print("cancel", "실패, 핀넘버로")
-                                DispatchQueue.main.async {
-                                    self.pincode = true
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        self.main = true // pincode 없으면 앱 보호 안하겠다는 것
-                    }
-                }
+                // JWT가 있을 때 하는 로직 - JWT가 없으면 인증 화면으로!
+                // 로컬 인증 함수는 JWT가 있으면 실행되면 안된다.
+                localAuthenticate()
             default: break
             }
         })
-        
     }
     
+}
+
+extension DaDaIkSeonApp {
+    func localAuthenticate() {
+        switch root {
+        case .none:
+            if nil != PincodeManager().loadPincode() {
+                BiometricIDAuth().authenticateUser { result in
+                    if result == nil { // 생체인증 성공
+                        DispatchQueue.main.async { root = .main }
+                    } else {            // 생체인증 실패
+                        DispatchQueue.main.async { root = .localAuth}
+                    }
+                }
+            } else { // pincode 없으면 앱 보호 안하겠다는 것
+                DispatchQueue.main.async { root = .main }
+            }
+        default:
+            return
+        }
+    }
+}
+
+enum DaDaIkSeonAppRootViews {
+    case main
+    case localAuth
+    case networkAuth
+    case none
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
@@ -49,6 +49,7 @@ struct DaDaIkSeonApp: App {
 }
 
 extension DaDaIkSeonApp {
+    
     func localAuthenticate() {
         switch root {
         case .none:
@@ -67,11 +68,12 @@ extension DaDaIkSeonApp {
             return
         }
     }
-}
+    
+    enum DaDaIkSeonAppRootViews {
+        case main
+        case localAuth
+        case networkAuth
+        case none
+    }
 
-enum DaDaIkSeonAppRootViews {
-    case main
-    case localAuth
-    case networkAuth
-    case none
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Common/DaDaIkSeonApp.swift
@@ -15,7 +15,11 @@ struct DaDaIkSeonApp: App {
     
     var body: some Scene {
         
+        #if DEBUG
+        let service = MockTokenService()
+        #else
         let service = TokenService(StorageManager())
+        #endif
         
         WindowGroup {
             switch root {

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/View/MainView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/View/MainView.swift
@@ -139,7 +139,6 @@ struct MainView: View {
                             }
                         )
                 )
-                //.opacity(viewModel.state.tokenOnDrag == token ? 0.0 : 1.0)
             }
             
             if !viewModel.state.checkBoxMode {

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/View/MainView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/View/MainView.swift
@@ -12,7 +12,7 @@ struct MainView: View {
     
     // MARK: ViewModel
     
-    @ObservedObject var viewModel: AnyViewModel<MainState, MainInput>
+    @StateObject var viewModel: AnyViewModel<MainState, MainInput>
     
     // MARK: Property
     
@@ -28,7 +28,7 @@ struct MainView: View {
     // MARK: Initialization
     
     init(service: TokenServiceable) {
-        viewModel = AnyViewModel(MainViewModel(service: service))
+        _viewModel = StateObject(wrappedValue: AnyViewModel(MainViewModel(service: service)))
     }
     
     // MARK: Body

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/ViewModel/MainViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/ViewModel/MainViewModel.swift
@@ -15,7 +15,7 @@ final class MainViewModel: ViewModel {
     
     init(service: TokenServiceable) {
         state = MainState(service: service,
-                          filteredTokens: [],
+                          filteredTokens: service.excludeMainCell(),
                           isSearching: false,
                           mainToken: Token(),
                           checkBoxMode: false,

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/ViewModel/MainViewModel.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Main/ViewModel/MainViewModel.swift
@@ -14,6 +14,7 @@ final class MainViewModel: ViewModel {
     @Published var state: MainState
     
     init(service: TokenServiceable) {
+        
         state = MainState(service: service,
                           filteredTokens: service.excludeMainCell(),
                           isSearching: false,

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/View/PinCodeView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/View/PinCodeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 // 아래 모드에 따라 다르게 화면 전환이 일어난다.
 enum PinCodeViewMode {
-    case auth(_ pincode: String)
+    case auth(_ pincode: String) // 취소 버튼 프레임
     case setup
     case delete(_ pincode: String)
 }
@@ -191,10 +191,11 @@ private extension NumberPad {
             } else if value == cancelButton {
                 switch pincodeViewMode {
                 case .auth:
-                    Text("")
+                    Text("취소")
                         .font(.system(size: 15))
                         .fontWeight(.bold)
                         .foregroundColor(.pink1)
+                        .opacity(0)
                 default:
                     Text("취소")
                         .font(.system(size: 15))

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/View/SettingView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/View/SettingView.swift
@@ -165,72 +165,11 @@ struct SettingView: View {
             .padding(.horizontal, 10)
             
             // MARK: 기기 관리
-            
-            SettingGridView(title: "기기 관리", titleColor: .white) {
-                SettingRow(title: "여러 기기 사용하기", isLast: false) {
-                    Toggle(isOn: $stateManager.multiDeviceToggle, label: {Text("")})
-                        .onChange(of: stateManager.multiDeviceToggle, perform: { _ in
-                            viewModel.trigger(.multiDeviceToggle)
-                        })
-                }
-                ForEach(viewModel.state.devices, id: \.udid) { device in
-                    SettingRow(
-                        title: device.name ?? "",
-                        isLast: isLastDivice(udid: device.udid)
-                            && !isSelectedDevice(deviceID: device.udid)
-                    ) {
-                        isSelectedDevice(deviceID: device.udid) ?
-                            Image.chevronDown : Image.chevronRight
-                    }
-                    .onTapGesture {
-                        withAnimation {
-                            stateManager.newDeviceName = ""
-                            viewModel.trigger(.deviceInfoMode(device.udid ?? ""))
-                        }
-                    }
-                    
-                    if isSelectedDevice(deviceID: device.udid) {
-                        
-                        HStack {
-                            TextField(device.name ?? "", text: $stateManager.newDeviceName)
-                            Divider()
-                            Button(action: {
-                                viewModel.trigger(.deleteDevice(device.udid ?? ""))
-                            }, label: {
-                                Text("삭제").foregroundColor(Color.pink)
-                            })
-                            Button(action: {
-                                var newDevice = device
-                                newDevice.name = stateManager.newDeviceName
-                                viewModel.trigger(.editDevice(newDevice))
-                            }, label: {
-                                Text("확인").foregroundColor(Color.navy1)
-                            })
-                        }
-                        
-                        Text("\(viewModel.state.editErrorMessage.rawValue)")
-                        
-                        Divider()
-                        HStack {
-                            Text("디바이스 아이디:")
-                            Spacer()
-                            Text("\(device.udid ?? "")")
-                        }
-                        HStack {
-                            Text("모델 이름:")
-                            Spacer()
-                            Text("\(device.modelName ?? "")")
-                        }
-                        Divider().padding(0)
-                    }
-                }
-            }
-            .padding(.horizontal, 10)
-            .padding(.top, 10)
+            deviceSettingView
             
             Spacer()
         })
-        .fullScreenCover(isPresented: $stateManager.pinCodeSetting){
+        .fullScreenCover(isPresented: $stateManager.pinCodeSetting) {
             stateManager.faceIDToggle ?
                             PinCodeView(
                                 mode: .delete(viewModel.state.service.pincode ?? "0000"),
@@ -248,6 +187,73 @@ struct SettingView: View {
 }
 
 extension SettingView {
+    
+    var deviceSettingView: some View {
+        
+        SettingGridView(title: "기기 관리", titleColor: .white) {
+            SettingRow(title: "여러 기기 사용하기", isLast: false) {
+                Toggle(isOn: $stateManager.multiDeviceToggle, label: {Text("")})
+                    .onChange(of: stateManager.multiDeviceToggle, perform: { _ in
+                        viewModel.trigger(.multiDeviceToggle)
+                    })
+            }
+            ForEach(viewModel.state.devices, id: \.udid) { device in
+                SettingRow(
+                    title: device.name ?? "",
+                    isLast: isLastDivice(udid: device.udid)
+                        && !isSelectedDevice(deviceID: device.udid)
+                ) {
+                    isSelectedDevice(deviceID: device.udid) ?
+                        Image.chevronDown : Image.chevronRight
+                }
+                .onTapGesture {
+                    withAnimation {
+                        stateManager.newDeviceName = ""
+                        viewModel.trigger(.deviceInfoMode(device.udid ?? ""))
+                    }
+                }
+                
+                if isSelectedDevice(deviceID: device.udid) {
+                    
+                    HStack {
+                        TextField(device.name ?? "", text: $stateManager.newDeviceName)
+                        Divider()
+                        Button(action: {
+                            viewModel.trigger(.deleteDevice(device.udid ?? ""))
+                        }, label: {
+                            Text("삭제").foregroundColor(Color.pink)
+                        })
+                        Button(action: {
+                            var newDevice = device
+                            newDevice.name = stateManager.newDeviceName
+                            viewModel.trigger(.editDevice(newDevice))
+                        }, label: {
+                            Text("확인").foregroundColor(Color.navy1)
+                        })
+                    }
+                    
+                    Text("\(viewModel.state.editErrorMessage.rawValue)")
+                    
+                    Divider()
+                    HStack {
+                        Text("디바이스 아이디:")
+                        Spacer()
+                        Text("\(device.udid ?? "")")
+                    }
+                    HStack {
+                        Text("모델 이름:")
+                        Spacer()
+                        Text("\(device.modelName ?? "")")
+                    }
+                    Divider().padding(0)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 10)
+        
+    }
+    
     
     func isLastDivice(udid: String?) -> Bool {
         guard let udid = udid else { return true }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/TokenCell/View/TokenCellView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/TokenCell/View/TokenCellView.swift
@@ -12,7 +12,7 @@ struct TokenCellView: View {
     
     // MARK: ViewModel
     
-    @StateObject var viewModel: AnyViewModel<TokenCellState, TokenCellInput>
+    @ObservedObject var viewModel: AnyViewModel<TokenCellState, TokenCellInput>
     
     // MARK: Property
     
@@ -26,12 +26,11 @@ struct TokenCellView: View {
          checkBoxMode: Binding<Bool>,
          isSelected: Bool?,
          refreshAction: (() -> Void)? = nil) {
-        _viewModel = StateObject(
-            wrappedValue: AnyViewModel(
-                TokenCellViewModel(service: service,
-                                   token: token,
-                                   isMainCell: isMain,
-                                   refreshAction: refreshAction)))
+        viewModel = AnyViewModel(
+            TokenCellViewModel(service: service,
+                               token: token,
+                               isMainCell: isMain,
+                               refreshAction: refreshAction))
         self.isMainCell = isMain
         self.isSelected = isSelected ?? false
         _checkBoxMode = checkBoxMode

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/TokenCell/View/TokenCellView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/TokenCell/View/TokenCellView.swift
@@ -12,7 +12,7 @@ struct TokenCellView: View {
     
     // MARK: ViewModel
     
-    @ObservedObject var viewModel: AnyViewModel<TokenCellState, TokenCellInput>
+    @StateObject var viewModel: AnyViewModel<TokenCellState, TokenCellInput>
     
     // MARK: Property
     
@@ -26,11 +26,12 @@ struct TokenCellView: View {
          checkBoxMode: Binding<Bool>,
          isSelected: Bool?,
          refreshAction: (() -> Void)? = nil) {
-        
-        viewModel = AnyViewModel(TokenCellViewModel(service: service,
-                                                    token: token,
-                                                    isMainCell: isMain,
-                                                    refreshAction: refreshAction))
+        _viewModel = StateObject(
+            wrappedValue: AnyViewModel(
+                TokenCellViewModel(service: service,
+                                   token: token,
+                                   isMainCell: isMain,
+                                   refreshAction: refreshAction)))
         self.isMainCell = isMain
         self.isSelected = isSelected ?? false
         _checkBoxMode = checkBoxMode

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Services/Token/TokenService.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Services/Token/TokenService.swift
@@ -93,9 +93,9 @@ final class TokenService: TokenServiceable {
         idList.forEach { id in
             tokens.removeAll(where: { $0.id == id })
         }
+        _ = storageManager.storeTokens(tokens)
         if tokens.count == 0 { return }
         updateMainWithFirstToken()
-        _ = storageManager.storeTokens(tokens)
     }
     
     func removeToken(_ id: UUID) {


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- inactive 상태일 때 바로 생체인증 적용 모드로 변경
- 취소 버튼 수정
- 키체인 삭제 안되었던 것 수정

## :hammer: 변경로직

- 메인 뷰모델을 @StateObject로 바꿔주었더니 해결되었습니다. 알아보니, StateObject는 원천 데이터라서 뷰가 새롭게 갱신 될 때 다시 생성되지 않는다고 합니다. 하지만 ObservableObject는 새롭게 생성된다고 합니다. 이러한 이슈 때문에 뷰가 갱신되면서 뷰모델도 새롭게 갱신되고, 이 때 이상한 셀이 주입된 것 같습니다. 
- 그래서 다른 원천 데이터도 ObservedObject로 바꾸려고 했습니다. TokenCellViewModel을 바꿨는데, 이번엔 또 메인 셀 뷰가 이상하게 표시 되었습니다. 그래서 다시 ObservedObject로 바꾸어주었습니다. 
- 토큰 삭제할 때, 메인 셀 재지정을 위한 로직에서, 토큰 개수가 0개면 return하는 코드가 있었습니다. 그런데 키체인 삭제 코드를 이 밑에 놓아서 마지막 토큰을 삭제할 때 키체인에 반영되지 않았었습니다. 그래서 위 쪽으로 옮겨주었습니다. 
- App Struct에서 로그인 화면, 메인화면, 핀코드 화면을 나눠주는 enum 타입을 만들어주었습니다. 이 값을 State로 선언하여, 변경되면 해당 뷰로 이동하도록 했습니다. 

## :lock: 관련 이슈(닫을 이슈)

- close #285
