### PR TITLE
[BE] totp 반복 로그인 제한

### DIFF
--- a/WEB/BE/controllers/web/auth/index.js
+++ b/WEB/BE/controllers/web/auth/index.js
@@ -43,8 +43,7 @@ const authController = {
   },
 
   async logInSuccess(req, res, next) {
-    const { action, id } = req.body;
-
+    const { action, id, totp } = req.body;
     if (action !== ACIONS.LOGIN) return next(createError(401, '잘못된 요청입니다'));
     const csrfToken = makeRandom();
     req.session.user = id;
@@ -53,6 +52,7 @@ const authController = {
     const { ip } = req;
     const params = await makeLogData({ ip: ip.substring(7), userAgent, id, sid: req.session.id });
     const [{ user }] = await Promise.all([authService.getUserById({ id }), logService.insert({ params })]);
+    await authService.updateOTP({ id, totp });
 
     res.cookie('csrfToken', csrfToken, {
       maxAge: 2 * 60 * 60 * 1000,

--- a/WEB/BE/middlewares/verifyJWT.js
+++ b/WEB/BE/middlewares/verifyJWT.js
@@ -10,6 +10,11 @@ const verifyJWT = {
       const { id, action } = JWT.verify(authToken, process.env.ENCRYPTIONKEY);
       req.body.id = id;
       req.body.action = action;
+
+      const lastOtp = await authService.getOTPById({ id });
+      if (String(lastOtp) === digits)
+        next(createError(400, '한번 사용된 OTP입니다 다음 OTP 정보를 이용하세요'));
+
       const secretKey = (await authService.getAuthById({ id })).secret_key;
       const result = totp.verifyDigits(secretKey, digits);
       if (!result) next(createError(400, 'TOTP 6자리가 틀렸습니다.'));

--- a/WEB/BE/models/WEB/AUTHS.js
+++ b/WEB/BE/models/WEB/AUTHS.js
@@ -37,6 +37,10 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         defaultValue: 0,
       },
+      last_totp: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
     },
     {
       sequelize,

--- a/WEB/BE/services/web/auth/index.js
+++ b/WEB/BE/services/web/auth/index.js
@@ -60,6 +60,16 @@ const authService = {
     const result = await authsModel.update(query, { where });
     return result;
   },
+
+  async updateOTP({ id, totp }) {
+    const result = await authsModel.update({ last_totp: totp }, { where: { id } });
+    return result;
+  },
+
+  async getOTPById({ id }) {
+    const result = await authsModel.findOne({ where: { id } });
+    return result.last_totp;
+  },
 };
 
 module.exports = authService;


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- auth 모델 수정
  - last_totp 정보 추가
- 로그인시 last_totp 정보 갱신
- 로그인에 사용된 otp 와 last_totp 정보가 동일할 경우 로그인 못하게 막기
  - API 메시지로 '한번 사용된 OTP입니다 다음 OTP 정보를 이용하세요' 넘겨줌

## :hammer: 변경로직

- 모델 변경이기 때문에 배포 서버의 auth 에 last_totp 추가 또는 새로 만들기 필요
  - 별다른 옵션은 없으며 타입은 Integer 

## :camera_flash: 스크린샷 (Optional)
![image](https://user-images.githubusercontent.com/33455696/102165558-e9b3ec80-3ece-11eb-98c0-48eecf96c571.png)
## :lock: 관련 이슈(닫을 이슈)

- close #305 #306 #309
