### PR TITLE
[FE] Axios Interceptor 설정 및 SessionAuthentication 리팩토링

### DIFF
--- a/WEB/BE/middlewares/sessionAuthentication.js
+++ b/WEB/BE/middlewares/sessionAuthentication.js
@@ -4,7 +4,7 @@ const sessionAuthentication = {
   sessionCheck(req, res, next) {
     const { CSRF_TOKEN } = req.session;
     const { csrfToken } = req.query;
-    if (!req.session.user && CSRF_TOKEN !== csrfToken) {
+    if (!req.session.user || CSRF_TOKEN !== csrfToken) {
       res.clearCookie('csrfToken');
       return next(createError(401, '로그아웃되어 권한이 없습니다.'));
     }
@@ -15,7 +15,6 @@ const sessionAuthentication = {
   },
 
   sessionLogout(req, res, next) {
-    // key 유무 확인을 먼저 해야하나?????
     req.session.destroy((err) => {
       if (err) {
         throw err;

--- a/WEB/BE/middlewares/sessionAuthentication.js
+++ b/WEB/BE/middlewares/sessionAuthentication.js
@@ -2,12 +2,14 @@ const createError = require('http-errors');
 
 const sessionAuthentication = {
   sessionCheck(req, res, next) {
-    const { csrfToken } = req.cookies;
-    // if (!req.session.key && req.session.CSRF_TOKEN !== CSRFTOKEN) {
-    if (!req.session.user) {
+    const { CSRF_TOKEN } = req.session;
+    const { csrfToken } = req.query;
+    if (!req.session.user && CSRF_TOKEN !== csrfToken) {
       res.clearCookie('csrfToken');
       return next(createError(401, '로그아웃되어 권한이 없습니다.'));
     }
+    console.log(req.session);
+    console.log(req.query);
     res.cookie('csrfToken', csrfToken, {
       maxAge: 2 * 60 * 60 * 1000,
     });

--- a/WEB/BE/middlewares/sessionAuthentication.js
+++ b/WEB/BE/middlewares/sessionAuthentication.js
@@ -8,8 +8,6 @@ const sessionAuthentication = {
       res.clearCookie('csrfToken');
       return next(createError(401, '로그아웃되어 권한이 없습니다.'));
     }
-    console.log(req.session);
-    console.log(req.query);
     res.cookie('csrfToken', csrfToken, {
       maxAge: 2 * 60 * 60 * 1000,
     });

--- a/WEB/FE/src/api/config.ts
+++ b/WEB/FE/src/api/config.ts
@@ -1,0 +1,16 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+const Axios = axios.create({
+  headers: { 'X-CSRF': 'X-CSRF' },
+});
+
+Axios.interceptors.request.use((value: AxiosRequestConfig) => {
+  const config = value;
+  config.params = {
+    csrfToken: document.cookie.split('csrfToken=')[1],
+    ...config.params,
+  };
+  return config;
+});
+
+export default Axios;

--- a/WEB/FE/src/api/index.ts
+++ b/WEB/FE/src/api/index.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-
-axios.defaults.headers['X-CSRF'] = 'X-CSRF';
+import axios from './config';
 
 interface UserInfo {
   id: string;


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- Axios Inceptions 설정
  - params 의 값으로 CSRF Token Cookie 값을 설정해줬습니다.(로그인하기 전에는 undefine값을 갖고있습니다)
- Axios 적용
- SessionAuthentication 미들웨어 안에서 세션을 체크할 때 query로 들어온 csrf token값과 세션에 존재하는 csrf token을 비교하였습니다.

## :hammer: 변경로직

```javascript
  sessionCheck(req, res, next) {
    const { CSRF_TOKEN } = req.session;
    const { csrfToken } = req.query;
    if (!req.session.user && CSRF_TOKEN !== csrfToken) {
      res.clearCookie('csrfToken');
      return next(createError(401, '로그아웃되어 권한이 없습니다.'));
    }
    ....
  }
```

## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #331
