### PR TITLE
[FE] Axios Response Interceptor 설정

### DIFF
--- a/WEB/FE/src/api/config.ts
+++ b/WEB/FE/src/api/config.ts
@@ -18,9 +18,9 @@ Axios.interceptors.request.use((value: AxiosRequestConfig) => {
 Axios.interceptors.response.use(
   (response) => response,
   (error) => {
+    alert(`${error.response?.data?.message || error.message}`);
     if (error.response.status === 401) {
       storageHandler.clear();
-      alert(error.response.data.message);
       window.location.reload();
     }
     return Promise.reject(error);

--- a/WEB/FE/src/api/config.ts
+++ b/WEB/FE/src/api/config.ts
@@ -1,4 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
+import storageHandler from '@utils/localStorage';
+import { message } from '../utils/message';
 
 const Axios = axios.create({
   headers: { 'X-CSRF': 'X-CSRF' },
@@ -12,5 +14,17 @@ Axios.interceptors.request.use((value: AxiosRequestConfig) => {
   };
   return config;
 });
+
+Axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response.status === 401) {
+      storageHandler.clear();
+      alert(error.response.data.message);
+      window.location.reload();
+    }
+    return Promise.reject(error);
+  },
+);
 
 export default Axios;

--- a/WEB/FE/src/components/MyPage/MyPageContainer.tsx
+++ b/WEB/FE/src/components/MyPage/MyPageContainer.tsx
@@ -118,14 +118,10 @@ function MyPageContainer({}: MyPageContainerProps): JSX.Element {
   }, []);
 
   useEffect(() => {
-    receiveLogs(page)
-      .then((data: any) => {
-        setLogs(data.result.rows);
-        setMaxPage(Math.ceil(data.result.count / 6));
-      })
-      .catch((err: any) => {
-        alert(`${err.response?.data?.message || err.message}`);
-      });
+    receiveLogs(page).then((data: any) => {
+      setLogs(data.result.rows);
+      setMaxPage(Math.ceil(data.result.count / 6));
+    });
   }, [page]);
 
   return (

--- a/WEB/FE/src/components/MyPage/MyPageContainer.tsx
+++ b/WEB/FE/src/components/MyPage/MyPageContainer.tsx
@@ -124,8 +124,7 @@ function MyPageContainer({}: MyPageContainerProps): JSX.Element {
         setMaxPage(Math.ceil(data.result.count / 6));
       })
       .catch((err: any) => {
-        alert(`${err.response?.data?.message || err.message} 다시 로그인해주세요.`);
-        storageHandler.clear();
+        alert(`${err.response?.data?.message || err.message}`);
       });
   }, [page]);
 


### PR DESCRIPTION
## :white_check_mark: 작업 내용

-  Local Storage 삭제
-  Page Reload

## :hammer: 변경로직

```javascript
Axios.interceptors.response.use(
  (response) => response,
  (error) => {
    alert(`${error.response?.data?.message || error.message}`);
    if (error.response.status === 401) {
      storageHandler.clear();
      window.location.reload();
    }
    return Promise.reject(error);
  },
);
```
고민했던 부분은 MyPage에서는 401 Error에 대한 처리로 Local Storage를 삭제해주고 alert로 권한이 없음을 알려주고 있었는데 interceptor를 설정하면서 그부분이 필요없어졌습니다. 그래서 모든 에러의 알림을 interceptor에서 띄워주기로 결정하였습니다. 또한 에러에 대한 추가적인 조치나 작업이 필요하다면 그 때 컴포넌트에서 catch로 잡아서 에러를 처리해주면 좋을 것 같다는 판단을 내려 MyPage에 있던 catch는 제거했습니다 !

## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #343
