### PR TITLE
[iOS] SettingView 네트워크 정리 

### DIFF
--- a/iOS/DaDaIkSeon/DaDaIkSeon/Model/Token.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Model/Token.swift
@@ -16,6 +16,11 @@ struct Token: Identifiable, Codable, Equatable {
     var icon: String?
     var isMain: Bool?
     
+    enum CodingKeys: String, CodingKey {
+        case id, key, name, color, icon
+        case isMain = "is_Main"
+    }
+    
     static func == (lhs: Token, rhs: Token) -> Bool {
         lhs.id == rhs.id
     }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Network/Setting/SettingNetworkManager.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Network/Setting/SettingNetworkManager.swift
@@ -19,8 +19,13 @@ final class SettingNetworkManager: Requestable {
         let settingEndpoint: SettingEndpoint = .patchEmail(email: email)
         request(settingEndpoint) { result in
             switch result {
-            case .networkSuccess:
-                completion(.emailEdit)
+            case .networkSuccess(let data):
+                switch data.responseCode {
+                case (200..<300):
+                    completion(.emailEdit)
+                default:
+                    completion(.ETCError)
+                }
             case .networkError:
                 completion(.dataParsingError)
             case .networkFail:
@@ -37,8 +42,13 @@ final class SettingNetworkManager: Requestable {
                                                             isBackup: backup)
         request(settingEndpoint) { result in
             switch result {
-            case .networkSuccess:
-                completion(.backupToggle)
+            case .networkSuccess(let data):
+                switch data.responseCode {
+                case (200..<300):
+                    completion(.backupToggle)
+                default:
+                    completion(.ETCError)
+                }
             case .networkError:
                 completion(.dataParsingError)
             case .networkFail:
@@ -46,15 +56,20 @@ final class SettingNetworkManager: Requestable {
             }
         }
     }
-
+    
     func changeMultiDevice(multiDevice: Bool,
                            completion: @escaping (SettingNetworkResult) -> Void) {
         
         let settingEndpoint: SettingEndpoint = .patchMultiDevice(isMultiDevice: multiDevice)
         request(settingEndpoint) { result in
             switch result {
-            case .networkSuccess:
-                completion(.multiDeviceToggle)
+            case .networkSuccess(let data):
+                switch data.responseCode {
+                case (200..<300):
+                    completion(.multiDeviceToggle)
+                default:
+                    completion(.ETCError)
+                }
             case .networkError:
                 completion(.dataParsingError)
             case .networkFail:
@@ -69,8 +84,13 @@ final class SettingNetworkManager: Requestable {
         let settingEndpoint: SettingEndpoint = .patchDevice(udid: udid, name: name)
         request(settingEndpoint) { result in
             switch result {
-            case .networkSuccess:
-                completion(.deviceNameEdit)
+            case .networkSuccess(let data):
+                switch data.responseCode {
+                case (200..<300):
+                    completion(.deviceNameEdit)
+                default:
+                    completion(.ETCError)
+                }
             case .networkError:
                 completion(.dataParsingError)
             case .networkFail:
@@ -85,9 +105,14 @@ final class SettingNetworkManager: Requestable {
         let settingEndpoint: SettingEndpoint = .deleteDevice(udid: udid)
         request(settingEndpoint) { result in
             switch result {
-            case .networkSuccess:
-                completion(.deviceDelete)
-            case .networkError(let error):
+            case .networkSuccess(let data):
+                switch data.responseCode {
+                case (200..<300):
+                    completion(.deviceDelete)
+                default:
+                    completion(.ETCError)
+                }
+            case .networkError:
                 completion(.dataParsingError)
             case .networkFail:
                 completion(.networkError)

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/Usecase/SettingNetworkResult.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/Usecase/SettingNetworkResult.swift
@@ -13,6 +13,7 @@ enum SettingNetworkResult {
     case multiDeviceToggle
     case backupToggle
     case deviceNameEdit
+    case deviceNameEditSuccess(_ devices: [Device])
     case deviceDelete
     case accessError403
     case messageError

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/Usecase/SettingUsecase.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/Usecase/SettingUsecase.swift
@@ -94,6 +94,16 @@ extension SettingView {
         @Published var pinCodeSetting: Bool = false
         
         @Published var deviceAlert: Bool = false
+        
+        func reset() {
+            newEmail = Entry(limit: 30)
+            newPassword = Entry(limit: 15)
+            newPasswordCheck = Entry(limit: 15)
+            newDeviceName = Entry(limit: 10)
+            faceIDToggle = false
+            pinCodeSetting = false
+            deviceAlert = false
+        }
     }
     
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/View/SettingView.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/View/SettingView.swift
@@ -58,6 +58,7 @@ struct SettingView: View {
         .edgesIgnoringSafeArea(.bottom)
         .onAppear {
             viewModel.trigger(.refresh)
+            stateManager.reset()
         }
     }
 }

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+Email.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+Email.swift
@@ -21,7 +21,7 @@ extension SettingViewModel {
                             self.state.email = email
                         }
                     default:
-                        print("뭐지")
+                        print("")
                     }
                 }
                 state.email = state.service.readEmail() ?? ""

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+Email.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+Email.swift
@@ -20,7 +20,8 @@ extension SettingViewModel {
                         DispatchQueue.main.async {
                             self.state.email = email
                         }
-                    default: break
+                    default:
+                        print("뭐지")
                     }
                 }
                 state.email = state.service.readEmail() ?? ""

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+MultiDevice.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+MultiDevice.swift
@@ -36,7 +36,13 @@ extension SettingViewModel {
             state.service.updateDevice(
                 device, completion: { result in
                     switch result {
-                    default: break
+                    case .deviceNameEditSuccess(let devices):
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            self.state.devices = devices
+                        }
+                    default:
+                        print("디바이스 이름 바꾸기 실패")
                     }
                 })
             state.devices = state.service.readDevice() ?? Device.dummy()

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+MultiDevice.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Scene/Setting/ViewModel/SettingViewModel+MultiDevice.swift
@@ -50,6 +50,13 @@ extension SettingViewModel {
             if state.selectedDeviceID != currentUDID {
                 state.service.deleteDevice(state.selectedDeviceID, completion: { result in
                     switch result {
+                    case .deviceDelete:
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            self.state.devices.removeAll(where: {
+                                $0.udid == self.state.selectedDeviceID
+                            })
+                        }
                     default: break
                     }
                 })

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Services/SettingService/MockSettingService.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Services/SettingService/MockSettingService.swift
@@ -52,9 +52,15 @@ class MockSettingService: SettingServiceable {
     func updateEmail(_ email: String, completion: @escaping (SettingNetworkResult) -> Void) {
         SettingNetworkManager.shared
             .changeEmail(email: email) { [weak self] result in
-                guard let self = self else { return }
-                self.user.email = email
-                completion(result)
+                switch result {
+                case .emailEdit:
+                    guard let self = self else { return }
+                    self.user.email = email
+                    completion(result)
+                default:
+                    completion(result)
+                }
+                
             }
     }
     

--- a/iOS/DaDaIkSeon/DaDaIkSeon/Services/Token/TokenService.swift
+++ b/iOS/DaDaIkSeon/DaDaIkSeon/Services/Token/TokenService.swift
@@ -62,6 +62,10 @@ final class TokenService: TokenServiceable {
                         } else { // 서버가 최신
                             // 서버 데이터를 로컬에 저장 - 복호화 시도 - 성공 or 실패
                             if let tokens = serverData.tokens {
+                                if tokens.count == 0 {
+                                    updateView(.noTokens)
+                                    return
+                                }
                                 switch self.decryptTokenKeys(tokens: tokens) {
                                 case .successLoad(let decryptedResult): // 복호화 성공
                                     if let decryptedTokens = decryptedResult.tokens {


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 완전히 네트워크 처리가 되었을 때에만 UI 변경되도록 변경
- 세팅뷰 모든 네트워크 연결 완료

## :hammer: 변경로직

- 아직 세팅뷰에서 변경사항이 생길 때 유저 디폴트로 저장해주는 작업을 하지 못했습니다. 지금은 네트워크가 잘 연결되어 괜찮짐만, 네트워크가 연결되지 않은 상태에 있을 때 유저 디폴트에 있는 값을 띄워줘야 합니다. 이 값이 항상 네트워크와 연결되어 있었던 최신의 상태를 가지도록, 변경사항이 있을 때 마다 유저 디폴트에도 저장해주어야 합니다. -> 이건 토큰에서도 마찬가지!
- 아직 이메일 변경이 되었다 안되었다 하는데, 정확한 이유는 내일 백엔드 팀원들과 이야기해보아야 합니다. 

