### PR TITLE
[FE] useTOTPModal 구현

### DIFF
--- a/WEB/FE/src/api/index.ts
+++ b/WEB/FE/src/api/index.ts
@@ -57,7 +57,7 @@ interface loginWithOTPParams {
 }
 
 interface loginWithOTPResponse {
-  result: boolean;
+  userName: string;
 }
 
 export const loginWithOTP = async (params: loginWithOTPParams): Promise<loginWithOTPResponse> => {

--- a/WEB/FE/src/components/LogIn/LogInContainer.tsx
+++ b/WEB/FE/src/components/LogIn/LogInContainer.tsx
@@ -31,7 +31,7 @@ const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
     setModalDisabled(false);
     setIsModalOpen(false);
   };
-  const onClickModal = () => {
+  const onReIssueQRCode = () => {
     setHasTOTPModalError(false);
     if (window.confirm('QR 재등록 Email을 전송하시겠습니까? \n이전에 사용된 OTP 정보는 삭제됩니다.')) {
       executeRecaptcha('sendSecretKeyEmail')
@@ -80,7 +80,7 @@ const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
         onChange={setTOTP}
         onSubmit={onSubmitOTP}
         onClose={onCloseModal}
-        onClick={onClickModal}
+        onReIssueQRCode={onReIssueQRCode}
         hasErrored={hasTOTPModalError}
         disabled={modalDisabled}
         errorMsg={errorMsg}

--- a/WEB/FE/src/components/LogIn/LogInContainer.tsx
+++ b/WEB/FE/src/components/LogIn/LogInContainer.tsx
@@ -2,74 +2,46 @@ import React, { useState } from 'react';
 import { LogInForm } from '@components/LogIn/LogInForm';
 import { TOTPModal } from '@components/TOTPModal/TOTPModal';
 import { loginWithOTP, sendSecretKeyEmail } from '@api/index';
-import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 import { useHistory } from 'react-router-dom';
 import { message } from '@utils/message';
 import storageHandler from '@utils/localStorage';
-
-const TOTP_LEN = 6;
+import { useTOTPModal } from '@hooks/useTOTPModal';
 
 interface LogInContainerProps {}
 
 const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
   const history = useHistory();
-  const { executeRecaptcha } = useGoogleReCaptcha();
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [TOTP, setTOTP] = useState('');
   const [authToken, setAuthToken] = useState('');
-  const [hasTOTPModalError, setHasTOTPModalError] = useState(false);
-  const [modalDisabled, setModalDisabled] = useState(false);
-  const [errorMsg, setErrorMsg] = useState('');
 
   const onSuccessLogInWithPassword = (authToken: string) => {
     setAuthToken(authToken);
-    setIsModalOpen(true);
-  };
-  const onCloseModal = () => {
-    setTOTP('');
-    setHasTOTPModalError(false);
-    setModalDisabled(false);
-    setIsModalOpen(false);
-  };
-  const onReIssueQRCode = () => {
-    setHasTOTPModalError(false);
-    if (window.confirm('QR 재등록 Email을 전송하시겠습니까? \n이전에 사용된 OTP 정보는 삭제됩니다.')) {
-      executeRecaptcha('sendSecretKeyEmail')
-        .then((reCaptchaToken: string) => sendSecretKeyEmail({ authToken, reCaptchaToken }))
-        .then(() => alert(message.EMAILSECRETKEYSUCCESS))
-        .catch((err: any) => onErrorWithOTP(err.response?.data?.message || err.message))
-        .finally(() => setModalDisabled(false));
-    }
-  };
-  const onErrorWithOTP = (errMsg: string) => {
-    setHasTOTPModalError(true);
-    setErrorMsg(errMsg);
-  };
-  const onSubmitOTP = () => {
-    setHasTOTPModalError(false);
-    if (TOTP.length < TOTP_LEN) {
-      onErrorWithOTP('전부 입력해 주세요~');
-      return;
-    }
-    setModalDisabled(true);
-    executeRecaptcha('LogInWithOTP')
-      .then((reCaptchaToken: string) => loginWithOTP({ authToken, totp: TOTP, reCaptchaToken }))
-      .then(({ userName }: { userName: string }) => successLoginHandler(userName))
-      .catch((err: any) => {
-        onErrorWithOTP(err.response?.data?.message || err.message);
-        if (err.response.status === 403) {
-          alert(err.response?.data?.message);
-          window.location.reload();
-        }
-      })
-      .finally(() => setModalDisabled(false));
+    openModal();
   };
 
-  const successLoginHandler = (userName: string) => {
+  const successLoginHandler = ({ userName }: { userName: string }) => {
     alert(message.SIGNINSUCCESS);
     storageHandler.set(userName);
     history.replace('/');
   };
+
+  const reIssueHandler = (reCaptchaToken: string) =>
+    sendSecretKeyEmail({ authToken, reCaptchaToken }).then(() => alert(message.EMAILSECRETKEYSUCCESS));
+
+  const submitHandler = (reCaptchaToken: string) =>
+    loginWithOTP({ authToken, totp: TOTP, reCaptchaToken }).then(successLoginHandler);
+
+  const {
+    isModalOpen,
+    openModal,
+    closeModal,
+    TOTP,
+    setTOTP,
+    hasTOTPModalError,
+    modalDisabled,
+    errorMsg,
+    onReIssueQRCode,
+    onSubmitOTP,
+  } = useTOTPModal({ reIssueHandler, submitHandler });
 
   return (
     <>
@@ -79,7 +51,7 @@ const LogInContainer = ({}: LogInContainerProps): JSX.Element => {
         TOTP={TOTP}
         onChange={setTOTP}
         onSubmit={onSubmitOTP}
-        onClose={onCloseModal}
+        onClose={closeModal}
         onReIssueQRCode={onReIssueQRCode}
         hasErrored={hasTOTPModalError}
         disabled={modalDisabled}

--- a/WEB/FE/src/components/TOTPModal/TOTPModal.tsx
+++ b/WEB/FE/src/components/TOTPModal/TOTPModal.tsx
@@ -10,7 +10,7 @@ interface TOTPModalProps {
   onChange: (otp: string) => any | React.Dispatch<React.SetStateAction<string>> | undefined;
   onSubmit: () => any;
   onClose: () => void;
-  onClick: () => void;
+  onReIssueQRCode: () => void;
   hasErrored?: boolean;
   disabled?: boolean;
   errorMsg?: string | undefined;
@@ -62,7 +62,7 @@ const TOTPModal = ({
   onChange,
   onSubmit,
   onClose,
-  onClick,
+  onReIssueQRCode,
   hasErrored,
   disabled,
   errorMsg,
@@ -93,7 +93,12 @@ const TOTPModal = ({
             />
             <Button text='취소' onClick={onClose} type='text' disabled={disabled} />
             <br />
-            <Button text='QR코드 재등록' onClick={onClick} type='text' style={{ marginTop: '1rem' }} />
+            <Button
+              text='QR코드 재등록'
+              onClick={onReIssueQRCode}
+              type='text'
+              style={{ marginTop: '1rem' }}
+            />
           </ButtonContainer>
         </Modal>
       ) : (

--- a/WEB/FE/src/hooks/useTOTPModal.ts
+++ b/WEB/FE/src/hooks/useTOTPModal.ts
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
+import { message } from '@utils/message';
+
+const TOTP_LEN = 6;
+const UNAUTHORIZED = 403;
+
+interface useTOTPModalProps {
+  reIssueHandler: (reCaptchaToken: string) => Promise<any>;
+  submitHandler: (reCaptchaToken: string) => Promise<any>;
+}
+
+interface useTOTPModalReturnType {
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+  hasTOTPModalError: boolean;
+  modalDisabled: boolean;
+  TOTP: string;
+  setTOTP: (otp: string) => void;
+  errorMsg: string;
+  onReIssueQRCode: () => void;
+  onSubmitOTP: () => void;
+}
+
+const useTOTPModal = ({ reIssueHandler, submitHandler }: useTOTPModalProps): useTOTPModalReturnType => {
+  const { executeRecaptcha } = useGoogleReCaptcha();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [TOTP, setTOTP] = useState('');
+  const [hasTOTPModalError, setHasTOTPModalError] = useState(false);
+  const [modalDisabled, setModalDisabled] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const openModal = () => setIsModalOpen(true);
+
+  const closeModal = () => {
+    setTOTP('');
+    setHasTOTPModalError(false);
+    setModalDisabled(false);
+    setIsModalOpen(false);
+    setErrorMsg('');
+  };
+
+  const handleError = (errMsg: string) => {
+    setHasTOTPModalError(true);
+    setErrorMsg(errMsg);
+  };
+
+  const onReIssueQRCode = () => {
+    setHasTOTPModalError(false);
+    setModalDisabled(true);
+    if (window.confirm('QR 재등록 Email을 전송하시겠습니까? \n이전에 사용된 OTP 정보는 삭제됩니다.')) {
+      executeRecaptcha('sendSecretKeyEmail')
+        .then(reIssueHandler)
+        .then(() => alert(message.EMAILSECRETKEYSUCCESS))
+        .catch((err: any) => handleError(err.response?.data?.message || err.message))
+        .finally(() => setModalDisabled(false));
+    }
+  };
+
+  const onSubmitOTP = () => {
+    setHasTOTPModalError(false);
+    if (TOTP.length < TOTP_LEN) {
+      handleError('전부 입력해 주세요~');
+      return;
+    }
+    setModalDisabled(true);
+    executeRecaptcha('LogInWithOTP')
+      .then(submitHandler)
+      .catch((err: any) => {
+        if (err.response.status === UNAUTHORIZED) {
+          alert(err.response?.data?.message);
+          window.location.reload();
+        }
+        handleError(err.response?.data?.message || err.message);
+        setModalDisabled(false);
+      });
+  };
+
+  return {
+    isModalOpen,
+    openModal,
+    closeModal,
+    TOTP,
+    setTOTP,
+    hasTOTPModalError,
+    modalDisabled,
+    errorMsg,
+    onReIssueQRCode,
+    onSubmitOTP,
+  };
+};
+
+export { useTOTPModal };


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- TOTPModal을 사용할 때 공통적으로 사용되는 부분을 커스텀 훅으로 추가
- LogInContainer, FindPasswordContainer에 적용

## :hammer: 변경로직

```javascript
  const submitHandler = (reCaptchaToken: string) =>
    findPasswordWithOTP({ authToken, totp: TOTP, reCaptchaToken }).then(() => findPasswordSuccess());

  const reIssueHandler = (reCaptchaToken: string) =>
    sendSecretKeyEmail({ authToken, reCaptchaToken }).then(() => alert(message.EMAILSECRETKEYSUCCESS));

  const {
    isModalOpen,
    openModal,
    closeModal,
    TOTP,
    setTOTP,
    hasTOTPModalError,
    modalDisabled,
    errorMsg,
    onReIssueQRCode,
    onSubmitOTP,
  } = useTOTPModal({ reIssueHandler, submitHandler });
```