### PR TITLE
[FE] useEmailInput, usePasswordInput, useSignUpInput 구현

### DIFF
--- a/WEB/FE/src/api/index.ts
+++ b/WEB/FE/src/api/index.ts
@@ -15,15 +15,15 @@ export const confirmEmailAPI = async (query: string): Promise<string> => {
   return data;
 };
 
-export const checkIDDuplicateAPI = async ({ id }: { id: string }): Promise<boolean> => {
+export const checkIDDuplicateAPI = async (params: string): Promise<boolean> => {
   const apiurl = `/api/auth/dup-id`;
-  const { data } = await axios.post(apiurl, { id });
+  const { data } = await axios.post(apiurl, { id: params });
   return data.result;
 };
 
-export const checkEmailDuplicateAPI = async ({ email }: { email: string }): Promise<boolean> => {
+export const checkEmailDuplicateAPI = async (params: string): Promise<boolean> => {
   const apiurl = `/api/user/dup-email`;
-  const { data } = await axios.post(apiurl, { email });
+  const { data } = await axios.post(apiurl, { email: params });
   return data.result;
 };
 

--- a/WEB/FE/src/components/ChangePass/ChangePasswordComponent.tsx
+++ b/WEB/FE/src/components/ChangePass/ChangePasswordComponent.tsx
@@ -1,22 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { useInput } from '@hooks/useInput';
+import React from 'react';
 import { PasswordInput } from '@components/common';
 import { Redirect, RouteComponentProps, useHistory } from 'react-router-dom';
 import { message } from '@utils/message';
 import { changePass } from '@/api';
+import { usePasswordInput } from '@/hooks';
 import { AuthForm } from '../common/AuthForm';
 
 const ChangePasswordComponent: React.FC<RouteComponentProps> = ({ location }): JSX.Element => {
   const { search } = location;
-  const [password, setPassword] = useInput('');
-  const [rePassword, setRePassword] = useInput('');
-  const [accord, setAccord] = useState(true);
+  const { password, rePassword, setPassword, setRePassword, accord } = usePasswordInput();
   const history = useHistory();
 
-  useEffect(() => {
-    if (password !== rePassword) setAccord(false);
-    else setAccord(true);
-  }, [password, rePassword]);
   if (!search) {
     return <Redirect to='/' />;
   }

--- a/WEB/FE/src/components/SignUpComponent/SignUpComponent.tsx
+++ b/WEB/FE/src/components/SignUpComponent/SignUpComponent.tsx
@@ -1,63 +1,36 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React from 'react';
 import { DefaultInput, PasswordInput, EmailInput, PhoneInput } from '@components/common';
 import { verify } from '@utils/verify';
-import { checkIDDuplicateAPI, checkEmailDuplicateAPI, registerUserAPI } from '@api/index';
+import { registerUserAPI } from '@api/index';
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 import { useHistory } from 'react-router-dom';
 import { Buffer } from 'buffer';
-import { useInput } from '@hooks/index';
+import { useInput, usePasswordInput, useSignUpInput } from '@hooks/index';
 import { AuthForm } from '@components/common/AuthForm';
 import { message } from '@utils/message';
 
 const SignUpComponent = (): JSX.Element => {
   const { executeRecaptcha } = useGoogleReCaptcha();
   const history = useHistory();
-  const [id, setID] = useInput('');
   const [name, setName] = useInput('');
   const [birth, setBirth] = useInput('');
-  const [password, setPassword] = useInput('');
-  const [rePassword, setRePassword] = useInput('');
-  const [accord, setAccord] = useState(true);
-  const [firstEmail, setFirstEmail] = useInput('');
-  const [secondEmail, setSecondEmail] = useInput('');
-  const [emailState, setEmailState] = useState(true);
+  const { password, setPassword, rePassword, setRePassword, accord } = usePasswordInput();
   const [firstPhone, setFirstPhone] = useInput('');
   const [secondPhone, setSecondPhone] = useInput('');
   const [thirdPhone, setThirdPhone] = useInput('');
-  const [idCheck, setIDCheck] = useState('');
-  const [emailCheck, setEmailCheck] = useState('');
-
-  const checkIDDuplicateEventHandler = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    try {
-      e.preventDefault();
-      const result = await checkIDDuplicateAPI({ id });
-      if (!result) {
-        alert(message.ALREADYID);
-        setIDCheck('-1');
-        return;
-      }
-      alert(message.POSSIBLEID);
-      setIDCheck(id);
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  const checkEmailDuplicateEventHandler = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    try {
-      e.preventDefault();
-      const result = await checkEmailDuplicateAPI({ email: `${firstEmail}@${secondEmail}` });
-      if (!result) {
-        alert(message.ALREADYEMAIL);
-        setEmailCheck('-1');
-        return;
-      }
-      alert(message.POSSIBLEEMAIL);
-      setEmailCheck(`${firstEmail}@${secondEmail}`);
-    } catch (err) {
-      console.error(err);
-    }
-  };
+  const {
+    idCheck,
+    emailCheck,
+    id,
+    setID,
+    firstEmail,
+    secondEmail,
+    setFirstEmail,
+    onChangeEmail,
+    emailState,
+    checkIDDuplicateEventHandler,
+    checkEmailDuplicateEventHandler,
+  } = useSignUpInput();
 
   const submitEventHandler = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -95,28 +68,6 @@ const SignUpComponent = (): JSX.Element => {
     history.push(`/QRCode/${url}`);
   };
 
-  const toggleAccord = useCallback(() => {
-    if (password !== rePassword) setAccord(false);
-    else setAccord(true);
-  }, [password, rePassword]);
-
-  useEffect(() => {
-    toggleAccord();
-  }, [toggleAccord]);
-
-  useEffect(() => {
-    if (secondEmail.indexOf('.') !== -1 || secondEmail === '') setEmailState(true);
-    else setEmailState(false);
-  }, [secondEmail]);
-
-  useEffect(() => {
-    setIDCheck('-1');
-  }, [id]);
-
-  useEffect(() => {
-    setEmailCheck('-1');
-  }, [firstEmail, secondEmail]);
-
   return (
     <AuthForm title='SIGN UP' action='' onSubmit={submitEventHandler} submitButtonText='회원가입'>
       <DefaultInput value={name} type='text' placeholder='Name' onChange={setName} />
@@ -149,7 +100,7 @@ const SignUpComponent = (): JSX.Element => {
         secondValue={secondEmail}
         type='text'
         onChangeFirst={setFirstEmail}
-        onChangeSecond={setSecondEmail}
+        onChangeSecond={onChangeEmail}
         buttonEvent={checkEmailDuplicateEventHandler}
         representWarning={emailState}
       />

--- a/WEB/FE/src/components/findID/findIDComponent.tsx
+++ b/WEB/FE/src/components/findID/findIDComponent.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 
 import { AuthForm } from '@components/common/AuthForm';
-import { useInput } from '@hooks/useInput';
 import { DefaultInput, EmailInput } from '@components/common';
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 import { findId } from '@api/index';
 import { useHistory } from 'react-router-dom';
 import { message } from '@utils/message';
+import { useEmailInput, useInput } from '@/hooks';
 
 const FindIDComponent = (): JSX.Element => {
   const { executeRecaptcha } = useGoogleReCaptcha();
-  const [firstEmail, setFirstEmail] = useInput('');
-  const [secondEmail, setSecondEmail] = useInput('');
+  const { firstEmail, setFirstEmail, secondEmail, onChangeEmail } = useEmailInput({});
   const [name, setName] = useInput('');
   const [birth, setBirth] = useInput('');
   const history = useHistory();
@@ -35,7 +34,7 @@ const FindIDComponent = (): JSX.Element => {
         firstValue={firstEmail}
         secondValue={secondEmail}
         onChangeFirst={setFirstEmail}
-        onChangeSecond={setSecondEmail}
+        onChangeSecond={onChangeEmail}
         type='text'
         representWarning
       />

--- a/WEB/FE/src/hooks/index.ts
+++ b/WEB/FE/src/hooks/index.ts
@@ -1,1 +1,4 @@
 export { useInput } from './useInput';
+export { useEmailInput } from './useEmailInput';
+export { usePasswordInput } from './usePasswordInput';
+export { useSignUpInput } from './useSignupInput';

--- a/WEB/FE/src/hooks/useEmailInput.ts
+++ b/WEB/FE/src/hooks/useEmailInput.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+interface returnProps {
+  firstEmail: string;
+  setFirstEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  secondEmail: string;
+  emailState: boolean;
+  onChangeEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+interface emailProps {
+  setEmailCheck?: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const useEmailInput = ({ setEmailCheck = undefined }: emailProps): returnProps => {
+  const [firstEmail, setFirstEmail] = useState('');
+  const [secondEmail, setSecondEmail] = useState('');
+  const [emailState, setEmailState] = useState(true);
+
+  const onChangeFirstEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFirstEmail(e.target.value);
+    if (setEmailCheck) setEmailCheck('-1');
+  };
+
+  const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSecondEmail(e.target.value);
+    if (e.target.value.indexOf('.') !== -1 || e.target.value === '') setEmailState(true);
+    else setEmailState(false);
+    if (setEmailCheck) setEmailCheck('-1');
+  };
+
+  return { firstEmail, setFirstEmail: onChangeFirstEmail, secondEmail, emailState, onChangeEmail };
+};
+
+export { useEmailInput };

--- a/WEB/FE/src/hooks/usePasswordInput.ts
+++ b/WEB/FE/src/hooks/usePasswordInput.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+interface passwordProps {
+  password: string;
+  rePassword: string;
+  setPassword: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  setRePassword: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  accord: boolean;
+}
+
+const usePasswordInput = (): passwordProps => {
+  const [password, setPassword] = useState('');
+  const [rePassword, setRePassword] = useState('');
+  const [accord, setAccord] = useState(true);
+
+  const makeOnChange = (setFunc: React.Dispatch<React.SetStateAction<string>>, isPassword: boolean) => {
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFunc(e.target.value);
+      const comparePassword = isPassword ? rePassword : password;
+      if (e.target.value !== comparePassword) setAccord(false);
+      else setAccord(true);
+    };
+  };
+
+  const onChangePassword = makeOnChange(setPassword, true);
+  const onChangeRePassword = makeOnChange(setRePassword, false);
+
+  return { password, rePassword, setPassword: onChangePassword, setRePassword: onChangeRePassword, accord };
+};
+
+export { usePasswordInput };

--- a/WEB/FE/src/hooks/useSignUpInput.ts
+++ b/WEB/FE/src/hooks/useSignUpInput.ts
@@ -1,0 +1,74 @@
+import { checkEmailDuplicateAPI, checkIDDuplicateAPI } from '@/api';
+import { useState } from 'react';
+import { message } from '../utils/message';
+import { useEmailInput } from './useEmailInput';
+
+interface returnProps {
+  idCheck: string;
+  emailCheck: string;
+  id: string;
+  setID: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  firstEmail: string;
+  secondEmail: string;
+  setFirstEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  emailState: boolean;
+  checkIDDuplicateEventHandler: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => Promise<void>;
+  checkEmailDuplicateEventHandler: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => Promise<void>;
+}
+
+const useSignUpInput = (): returnProps => {
+  const [idCheck, setIDCheck] = useState('');
+  const [emailCheck, setEmailCheck] = useState('');
+  const [id, setID] = useState('');
+  const { firstEmail, setFirstEmail, secondEmail, onChangeEmail, emailState } = useEmailInput({
+    setEmailCheck,
+  });
+
+  const viewMessage = (result: boolean, isId: boolean, value: string) => {
+    const setFunc = isId ? setIDCheck : setEmailCheck;
+    if (!result) {
+      alert(isId ? message.ALREADYID : message.ALREADYEMAIL);
+      setFunc('-1');
+      return;
+    }
+    alert(isId ? message.POSSIBLEID : message.POSSIBLEEMAIL);
+    setFunc(value);
+  };
+
+  const checkDuplicate = (value: string, isId: boolean) => {
+    return async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      const checkAPI = isId ? checkIDDuplicateAPI : checkEmailDuplicateAPI;
+      try {
+        e.preventDefault();
+        const result = await checkAPI(value);
+        viewMessage(result, isId, value);
+      } catch (err) {
+        alert(err);
+      }
+    };
+  };
+  const checkIDDuplicateEventHandler = checkDuplicate(id, true);
+  const checkEmailDuplicateEventHandler = checkDuplicate(`${firstEmail}@${secondEmail}`, false);
+
+  const onChangeId = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setID(e.target.value);
+    setIDCheck('-1');
+  };
+
+  return {
+    idCheck,
+    emailCheck,
+    id,
+    setID: onChangeId,
+    firstEmail,
+    secondEmail,
+    setFirstEmail,
+    onChangeEmail,
+    emailState,
+    checkIDDuplicateEventHandler,
+    checkEmailDuplicateEventHandler,
+  };
+};
+
+export { useSignUpInput };


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- useEmailInput Hook 구현 및 적용
- usePasswordInput Hook 구현 및 적용
- useSignUpInput 구현 및 적용

## :hammer: 변경로직

반복해서 사용된 컴포넌트들 중에 상태만을 사용하는 컴포넌트( DefaultInput, PhoneInput)을 제외하고, 상태 + 이벤트 핸들러 + onChange에 추가적인 작업이 필요한 것들만 custom Hook으로 만들어줬습니다.
```javascript
const makeOnChange = (setFunc: React.Dispatch<React.SetStateAction<string>>, isPassword: boolean) => {
    return (e: React.ChangeEvent<HTMLInputElement>) => {
      setFunc(e.target.value);
      const comparePassword = isPassword ? rePassword : password;
      if (e.target.value !== comparePassword) setAccord(false);
      else setAccord(true);
    };
  };

const onChangePassword = makeOnChange(setPassword, true);
const onChangeRePassword = makeOnChange(setRePassword, false);
```
만들면서 반복되는 함수들은 클로저를 활용해서 코드를 줄여봤습니다 !

## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #362
