### PR TITLE
[FE] API Generic Type지정 및 파일 분리

### DIFF
--- a/WEB/BE/controllers/web/user/index.js
+++ b/WEB/BE/controllers/web/user/index.js
@@ -103,7 +103,7 @@ const userController = {
     res.json({ message: 'ok' });
   },
 
-  async reSendEmail(req, res, next) {
+  async reSendEmail(req, res) {
     const { id } = req.body;
     const { user } = await authService.getUserById({ id });
     emailSender.SignUpAuthentication(

--- a/WEB/FE/src/api/index.ts
+++ b/WEB/FE/src/api/index.ts
@@ -1,14 +1,22 @@
+import {
+  UserInfo,
+  loginWithPasswordParams,
+  loginWithPasswordResponse,
+  loginWithOTPParams,
+  loginWithOTPResponse,
+  findPasswordWithOTPParams,
+  findIdParams,
+  findPasswordParams,
+  findPasswordReturn,
+  getUserReturn,
+  updateUserParmas,
+  receiveLogsReturn,
+  delSessionParmas,
+  sendPasswordParams,
+  sendSecretKeyEmailParams,
+  reSendReturn,
+} from '../types/apiType';
 import axios from './config';
-
-interface UserInfo {
-  id: string;
-  password: string;
-  email: string;
-  birth: string;
-  name: string;
-  phone: string;
-  reCaptchaToken: string;
-}
 
 export const confirmEmailAPI = async (query: string): Promise<string> => {
   const { data } = await axios.get(`/api/user/confirm-email?user=${query}`);
@@ -33,16 +41,6 @@ export const registerUserAPI = async (params: UserInfo): Promise<string> => {
   return data.url;
 };
 
-interface loginWithPasswordParams {
-  id: string;
-  password: string;
-  reCaptchaToken: string;
-}
-
-interface loginWithPasswordResponse {
-  authToken: string;
-}
-
 export const loginWithPassword = async (
   params: loginWithPasswordParams,
 ): Promise<loginWithPasswordResponse> => {
@@ -50,117 +48,67 @@ export const loginWithPassword = async (
   return data;
 };
 
-interface loginWithOTPParams {
-  authToken: string;
-  totp: string;
-  reCaptchaToken: string;
-}
-
-interface loginWithOTPResponse {
-  userName: string;
-}
-
 export const loginWithOTP = async (params: loginWithOTPParams): Promise<loginWithOTPResponse> => {
   const { data } = await axios.put('/api/auth', params);
   return data;
 };
 
-interface findPasswordWithOTPParams {
-  authToken: string;
-  totp: string;
-  reCaptchaToken: string;
-}
-
-export const findPasswordWithOTP = async (params: findPasswordWithOTPParams): Promise<any> => {
+export const findPasswordWithOTP = async (params: findPasswordWithOTPParams): Promise<string> => {
   const { data } = await axios.put('/api/auth/password/email', params);
   return data;
 };
 
-interface findIdParams {
-  email: string;
-  name: string;
-  birth: string;
-  reCaptchaToken: string;
-}
-
-export const findId = async (params: findIdParams): Promise<any> => {
+export const findId = async (params: findIdParams): Promise<boolean> => {
   const { data } = await axios.post('/api/user/find-id', params);
   return data;
 };
 
-interface findPasswordParams {
-  id: string;
-  name: string;
-  birth: string;
-  reCaptchaToken: string;
-}
-
-export const findPassword = async (params: findPasswordParams): Promise<any> => {
+export const findPassword = async (params: findPasswordParams): Promise<findPasswordReturn> => {
   const { data } = await axios.post('/api/auth/password/email', params);
   return data;
 };
 
-export const changePass = async (query: string, password: string): Promise<any> => {
+export const changePass = async (query: string, password: string): Promise<string> => {
   const { data } = await axios.patch(`/api/auth/password/email?user=${query}`, { password });
   return data;
 };
 
-interface sendSecretKeyEmailParams {
-  authToken: string;
-  reCaptchaToken: string;
-}
-
-export const sendSecretKeyEmail = async (params: sendSecretKeyEmailParams): Promise<any> => {
+export const sendSecretKeyEmail = async (params: sendSecretKeyEmailParams): Promise<string> => {
   const { data } = await axios.put(`/api/auth/secret-key/email`, params);
   return data;
 };
 
-interface sendPasswordParams {
-  password: string;
-}
-
-// MyPage에서 비밀번호 입력하여 확인할 때 사용
-export const sendPassword = async (params: sendPasswordParams): Promise<any> => {
+export const sendPassword = async (params: sendPasswordParams): Promise<boolean> => {
   const { data } = await axios.post(`api/auth/check-pw`, params);
   return data;
 };
 
-export const getUser = async (): Promise<any> => {
+export const getUser = async (): Promise<getUserReturn> => {
   const { data } = await axios.get('api/user');
   return data;
 };
 
-interface updateUserParmas {
-  name?: string;
-  email?: string;
-  phone?: string;
-  birth?: string;
-}
-
-export const updateUser = async (params: updateUserParmas): Promise<any> => {
+export const updateUser = async (params: updateUserParmas): Promise<string> => {
   const { data } = await axios.patch('api/user', params);
   return data;
 };
 
-export const receiveLogs = async (num: number): Promise<any> => {
+export const receiveLogs = async (num: number): Promise<receiveLogsReturn[]> => {
   const { data } = await axios.get(`api/log/${num}`);
   return data;
 };
 
-interface delSessionParmas {
-  sid?: string;
-}
-export const delSession = async (sid: delSessionParmas): Promise<any> => {
+export const delSession = async (sid: delSessionParmas): Promise<boolean> => {
   const { data } = await axios.patch('api/log/session', sid);
   return data;
 };
 
-export const logoutAPI = async (): Promise<any> => {
+export const logoutAPI = async (): Promise<boolean> => {
   const { data } = await axios.get('api/auth/logout');
   return data;
 };
 
-export const reSend = async (id: string): Promise<any> => {
+export const reSend = async (id: string): Promise<reSendReturn> => {
   const { data } = await axios.post('api/user/reSend', { id });
   return data;
 };

--- a/WEB/FE/src/components/MyPage/MyPageContainer.tsx
+++ b/WEB/FE/src/components/MyPage/MyPageContainer.tsx
@@ -9,7 +9,6 @@ import 'react-tabs/style/react-tabs.css';
 import { AxiosError } from 'axios';
 import { PasswordModal } from '@components/PasswordModal/PasswordModal';
 import { getUser, updateUser, sendPassword, receiveLogs } from '@api/index';
-import storageHandler from '@utils/localStorage';
 import { HeadingSection } from '@components/common/Section/HeadingSection';
 
 const UNAUTHORIZED = 401;

--- a/WEB/FE/src/components/StudyComponent/StudyComponent.tsx
+++ b/WEB/FE/src/components/StudyComponent/StudyComponent.tsx
@@ -3,9 +3,7 @@ import svgBackground from '@static/TOTPFrame.svg';
 import styled from 'styled-components';
 import { HeadingSection } from '@components/common/Section/HeadingSection';
 import { BlockSection } from '@components/common/Section/BlockSection';
-import { initialArrayData, initialStudyData } from '@utils/initialData';
-import { Drag } from './DragAndDrop/Drag';
-import { DropTarget } from './DragAndDrop/DropTarget';
+import { initialStudyData } from '@utils/initialData';
 import { MarkButton } from './MarkButton/MarkButton';
 import { StudyBox } from './StudyBox/StudyBox';
 
@@ -20,25 +18,6 @@ const BackGround = styled.div`
   height: 441px;
   background-position: center;
   position: relative;
-`;
-
-const DropContainer = styled.div<{ styles: any; isList: boolean }>`
-  position: ${(props) => (props.isList ? 'relative' : 'absolute')};
-  left: ${(props) => props.styles.left}px;
-  top: ${(props) => props.styles.top}px;
-  width: ${(props) => props.styles.width}px;
-  height: ${(props) => props.styles.height}px;
-  overflow: visible;
-  justify-content: ${(props) => (props.isList ? 'none' : 'center')};
-  display: flex;
-  flex-wrap: wrap;
-  margin: auto;
-  border: ${(props) => (props.isList ? '2px solid black' : 'none')};
-`;
-
-const DragImg = styled.img<{ styles: any }>`
-  width: ${(props) => props.styles.width - 5}px;
-  height: ${(props) => props.styles.height - 5}px;
 `;
 
 const Title = styled.div`

--- a/WEB/FE/src/types/apiType.ts
+++ b/WEB/FE/src/types/apiType.ts
@@ -92,3 +92,7 @@ export interface sendSecretKeyEmailParams {
   authToken: string;
   reCaptchaToken: string;
 }
+
+export interface reSendReturn {
+  message: string;
+}

--- a/WEB/FE/src/types/apiType.ts
+++ b/WEB/FE/src/types/apiType.ts
@@ -1,0 +1,94 @@
+export interface UserInfo {
+  id: string;
+  password: string;
+  email: string;
+  birth: string;
+  name: string;
+  phone: string;
+  reCaptchaToken: string;
+}
+
+export interface loginWithPasswordParams {
+  id: string;
+  password: string;
+  reCaptchaToken: string;
+}
+
+export interface loginWithPasswordResponse {
+  authToken: string;
+}
+
+export interface loginWithOTPParams {
+  authToken: string;
+  totp: string;
+  reCaptchaToken: string;
+}
+
+export interface loginWithOTPResponse {
+  userName: string;
+}
+
+export interface findPasswordWithOTPParams {
+  authToken: string;
+  totp: string;
+  reCaptchaToken: string;
+}
+
+export interface findIdParams {
+  email: string;
+  name: string;
+  birth: string;
+  reCaptchaToken: string;
+}
+
+export interface findPasswordParams {
+  id: string;
+  name: string;
+  birth: string;
+  reCaptchaToken: string;
+}
+
+export interface findPasswordReturn {
+  message: string;
+  authToken: string;
+}
+
+/// ////////////////////
+export interface getUserReturn {
+  user: {
+    birth: string;
+    email: string;
+    name: string;
+    phone: string;
+  };
+}
+
+export interface updateUserParmas {
+  name?: string;
+  email?: string;
+  phone?: string;
+  birth?: string;
+}
+
+export interface receiveLogsReturn {
+  key: string;
+  time: string;
+  device: string;
+  ip: string;
+  location: string;
+  isLoggedOut: boolean;
+  sessionId: string | undefined;
+}
+
+export interface delSessionParmas {
+  sid?: string;
+}
+
+export interface sendPasswordParams {
+  password: string;
+}
+
+export interface sendSecretKeyEmailParams {
+  authToken: string;
+  reCaptchaToken: string;
+}


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- API Generic Type지정
- 타입 types 폴더에 따로 빼놓기

## :hammer: 변경로직

- API.ts 폴더에 타입값들이 너무 많아져서 보기 싫은 것 같으면 
```javascript
import * as types from '@types/apiType.ts';
```
이렇게 수정해도 될 것 같습니다 !
그리고 @types 를 경로로 사용하면 문제가 발생하는데 다른분들도 문제가 발생하는지 한번 확인 가능할까요?!
제가 이전에 types가 어떤 것과 겹치는 느낌이어서 type으로 바꿨던 것 같은데 다시 types로 바뀌었네요 ㅎㅎ

## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #368
